### PR TITLE
Update fbbt_auth_attrib_licence.owl

### DIFF
--- a/fbbt/src/trunk/ontologies/fbbt_auth_attrib_licence.owl
+++ b/fbbt/src/trunk/ontologies/fbbt_auth_attrib_licence.owl
@@ -25,16 +25,16 @@
      xmlns:fbbt="http://purl.obolibrary.org/obo/fbbt#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/fbbt.owl">
         <oboInOwl:hasOBOFormatVersion rdf:datatype="&xsd;string">1.2</oboInOwl:hasOBOFormatVersion>
-        <contributor>Liria Masuda-Nakagawa</contributor>
-        <contributor>Michael Ashburner</contributor>
-        <contributor>Simon Reeve</contributor>
-        <contributor>Volker Hartenstein</contributor>
-        <contributor>Gary Grumbling</contributor>
-        <contributor>Kei Ito</contributor>
+        <dc:contributor>Liria Masuda-Nakagawa</dc:contributor>
+        <dc:contributor>Michael Ashburner</dc:contributor>
+        <dc:contributor>Simon Reeve</dc:contributor>
+        <dc:contributor>Volker Hartenstein</dc:contributor>
+        <dc:contributor>Gary Grumbling</dc:contributor>
+        <contributor>Kei Ito</dc:contributor>
         <dc:rights rdf:resource="http://creativecommons.org/licenses/by/3.0/"/>
         <fbbt:attributionURL rdf:resource="http://dx.doi.org/10.1186/2041-1480-4-32"/>
         <dc:creator rdf:resource="http://orcid.org/0000-0001-5948-3092"/>
-        <contributor rdf:resource="http://orcid.org/0000-0002-0587-9355"/>
+        <dc:contributor rdf:resource="http://orcid.org/0000-0002-0587-9355"/>
         <dc:creator rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
     </owl:Ontology>
     


### PR DESCRIPTION
contributor -> dc:contributor

Better standardisation  + this change is needed in order to reconcile AP usage between fbbt and vfb
