### PR TITLE
Lateral glia

### DIFF
--- a/fbbt/src/ontology/imports/flybase_import.obo
+++ b/fbbt/src/ontology/imports/flybase_import.obo
@@ -37,6 +37,11 @@ name: Myosuppressin
 is_a: SO:0000704
 
 [Term]
+id: http://flybase.org/reports/FBgn0011701
+name: reversed polarity
+is_a: SO:0000704
+
+[Term]
 id: http://flybase.org/reports/FBgn0012344
 name: Diuretic hormone 44
 is_a: SO:0000704


### PR DESCRIPTION
added 'embryonic/larval lateral glial cell' defined by repo expression (from several different precursor cells).
Repo expression added to relevant glial classes.
No evidence for whether this applies to adult glia (larval glia seem to get replaced), so adult term not made - this may be addressed in ticket #392 if info in FBrf0229106
fixes #295 
