### PR TITLE
Edits to QC

### DIFF
--- a/src/ontology/components/qc_assertions_unmerge.owl
+++ b/src/ontology/components/qc_assertions_unmerge.owl
@@ -14,5 +14,6 @@ AnnotationAssertion(obo:IAO_0000115 obo:RO_0000301 "A relation that holds betwee
 AnnotationAssertion(obo:IAO_0000115 obo:RO_0000302 "A relation that holds between a neuron that is synapsed_to another neuron or a neuron that is connected indirectly to another by a chain of neurons, each synapsed_to the next."@en)
 AnnotationAssertion(obo:IAO_format-version obo:FBbt_RO.owl "1.2")
 AnnotationAssertion(obo:IAO_0000115 obo:BFO_0000051 "a core relation that holds between a whole and its part"@en)
-
+AnnotationAssertion(obo:IAO_0000115 obo:IAO_0100001 "Add as annotation triples in the granting ontology"@en)
+AnnotationAssertion(obo:IAO_0000115 obo:RO_0002473 "x composed_primarily_of y if and only if more than half of the mass of x is made from y or units of the same type as y.")
 )

--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -176,9 +176,10 @@ post_release: fly_anatomy.obo reports/chado_load_check_simple.txt
 
 obo_qc_%.obo:
 	$(ROBOT) report -i $*.obo --profile qc-profile.txt --fail-on ERROR --print 5 -o $@.txt
-	
-obo_qc_$(ONT).owl:
-	$(ROBOT) report -i $(ONT).owl --profile qc-profile.txt --fail-on None --print 5 -o $@.txt
+
+# overides qc for fbbt.owl (no fail on error)	
+#obo_qc_$(ONT).owl:
+#	$(ROBOT) report -i $(ONT).owl --profile qc-profile.txt --fail-on None --print 5 -o $@.txt
 			
 obo_qc_%.owl:
 	$(ROBOT) merge -i $*.owl -i components/qc_assertions.owl unmerge -i components/qc_assertions_unmerge.owl -o $@ &&\


### PR DESCRIPTION
reinstated fail on error in makefile, added annotations to ignore to qc_assertions
stops failure due to multiple definitions on typedefs in PATO