### PR TITLE
Cell body rinds

### DIFF
--- a/src/patterns/dosdp_workshop/CBR_subregions/CBRs.csv
+++ b/src/patterns/dosdp_workshop/CBR_subregions/CBRs.csv
@@ -1,0 +1,25 @@
+defined_class	abbreviation	position	neuropil_name	neuropil_id	superrind_id	other_partonomy_name	other_partonomy_id	def_dbxref
+FBbt:00051000	rALad	anterodorsal	antennal lobe	FBbt:00007401	FBbt:00100211	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051001	rALl	lateral	antennal lobe	FBbt:00007401	FBbt:00100211	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051002	rALld	laterodorsal	antennal lobe	FBbt:00007401	FBbt:00100211	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051003	rALv	ventral	antennal lobe	FBbt:00007401	FBbt:00100211	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051004	rAOTUa	anterior	anterior optic tubercle	FBbt:00007059	FBbt:00048470	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051005	rAOTUl	lateral	anterior optic tubercle	FBbt:00007059	FBbt:00048470	lateral brain cell body rind	FBbt:00100201	FlyBase:FBrf0224194
+FBbt:00051006	rAOTUv	ventral	anterior optic tubercle	FBbt:00007059	FBbt:00048470	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051007	rAVLPa	anterior	anterior ventrolateral protocerebrum	FBbt:00040043	FBbt:00100209	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051008	rAVLPl	lateral	anterior ventrolateral protocerebrum	FBbt:00040043	FBbt:00100209	lateral brain cell body rind	FBbt:00100201	FlyBase:FBrf0224194
+FBbt:00051009	rCREa	anterior	crepine	FBbt:00045037	FBbt:00100288	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051010	rCREm	medial	crepine	FBbt:00045037	FBbt:00100288	cell body rind along the midline of the adult brain	FBbt:00111154	FlyBase:FBrf0224194
+FBbt:00051011	rLHd	dorsal	lateral horn	FBbt:00007053	FBbt:00007647	superior brain cell body rind	FBbt:00100308	FlyBase:FBrf0224194
+FBbt:00051012	rLHl	lateral	lateral horn	FBbt:00007053	FBbt:00007647	lateral brain cell body rind	FBbt:00100201	FlyBase:FBrf0224194
+FBbt:00051013	rLHp	posterior	lateral horn	FBbt:00007053	FBbt:00007647	posterior brain cell body rind	FBbt:00111153	FlyBase:FBrf0224194
+FBbt:00051014	rPLPl	lateral	posterior lateral protocerebrum	FBbt:00040044	FBbt:00100203	lateral brain cell body rind	FBbt:00100201	FlyBase:FBrf0224194
+FBbt:00051015	rPLPp	posterior	posterior lateral protocerebrum	FBbt:00040044	FBbt:00100203	posterior brain cell body rind	FBbt:00111153	FlyBase:FBrf0224194
+FBbt:00051016	rSADl	lateral	saddle	FBbt:00045048	FBbt:00049152	lateral brain cell body rind	FBbt:00100201	FlyBase:FBrf0224194
+FBbt:00051017	rSADmv	medioventral	saddle	FBbt:00045048	FBbt:00049152	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051018	rSIPa	anterior	superior intermediate protocerebrum	FBbt:00045032	FBbt:00049550	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051019	rSIPd	dorsal	superior intermediate protocerebrum	FBbt:00045032	FBbt:00049550	superior brain cell body rind	FBbt:00100308	FlyBase:FBrf0224194
+FBbt:00051020	rSLPa	anterior	superior lateral protocerebrum	FBbt:00040045	FBbt:00100202	anterior brain cell body rind	FBbt:00111151	FlyBase:FBrf0224194
+FBbt:00051021	rSLPd	dorsal	superior lateral protocerebrum	FBbt:00007054	FBbt:00100202	superior brain cell body rind	FBbt:00100308	FlyBase:FBrf0224194
+FBbt:00051022	rSLPp	posterior	superior lateral protocerebrum	FBbt:00040046	FBbt:00100202	posterior brain cell body rind	FBbt:00111153	FlyBase:FBrf0224194
+FBbt:00051023	rSMPd	dorsal	superior medial protocerebrum	FBbt:00007055	FBbt:00100204	superior brain cell body rind	FBbt:00100308	FlyBase:FBrf0224194

--- a/src/patterns/dosdp_workshop/CBR_subregions/CBRs.yaml
+++ b/src/patterns/dosdp_workshop/CBR_subregions/CBRs.yaml
@@ -1,0 +1,65 @@
+pattern_name: Cell_Body_Rind_Subregions
+description: for creating subregions of CBRs from Ito et al. (2014) BrainName paper.
+
+classes:
+  thing: owl:Thing
+  cell_body_rind_region: FBbt:00100200
+
+relations:
+  part_of: BFO:0000050
+  continuous_with: RO:0002150
+
+vars:
+  position: thing
+  neuropil_name: thing
+  neuropil_id: thing
+  superrind_id: thing
+  other_partonomy_name: thing
+  other_partonomy_id: thing
+  abbreviation: thing
+
+
+data_list_vars:
+  def_dbxref: xsd:string
+
+name:
+  text: "cell body rind of adult %s %s"
+  vars:
+    - position
+    - neuropil_name
+
+def:
+  text: "Adult cell body rind region that overlies the %s part of the %s (Ito et al., 2014). It is also part of the %s (Ito et al., 2014)."
+  vars:
+    - position
+    - neuropil_name
+    - other_partonomy_name
+  xrefs: def_dbxref
+
+generated_synonyms:
+  -
+    exact_synonym:
+    text: "%s"
+    vars:
+      - abbreviation
+    xrefs: def_dbxref
+    
+logical_axioms:
+  - 
+    axiom_type: subClassOf
+    text: "'part_of' some %s"
+    vars:
+      - superrind_id
+  - 
+    axiom_type: subClassOf
+    text: "'part_of' some %s"
+    vars:
+      - other_partonomy_id
+  - 
+    axiom_type: subClassOf
+    text: "'continuous_with' some %s"
+    vars:
+      - neuropil_id
+  - 
+    axiom_type: subClassOf
+    text: "'cell_body_rind_region'"

--- a/src/patterns/dosdp_workshop/CBR_subregions/CBRs_nosecondpart.csv
+++ b/src/patterns/dosdp_workshop/CBR_subregions/CBRs_nosecondpart.csv
@@ -1,0 +1,21 @@
+defined_class	abbreviation	position	neuropil_name	neuropil_id	superrind_id	def_dbxref
+FBbt:00051024	rGNGl	lateral	gnathal ganglion	FBbt:00014013	FBbt:00100210	FlyBase:FBrf0224194
+FBbt:00051025	rGNGv	ventral	gnathal ganglion	FBbt:00014013	FBbt:00100210	FlyBase:FBrf0224194
+FBbt:00051026	rLAa	anterior	lamina	FBbt:00003708	FBbt:00100206	FlyBase:FBrf0224194
+FBbt:00051027	rLAd	dorsal	lamina	FBbt:00003708	FBbt:00100206	FlyBase:FBrf0224194
+FBbt:00051028	rLAl	lateral	lamina	FBbt:00003708	FBbt:00100206	FlyBase:FBrf0224194
+FBbt:00051029	rLAm	medial	lamina	FBbt:00003708	FBbt:00100206	FlyBase:FBrf0224194
+FBbt:00051030	rLAp	posterior	lamina	FBbt:00003708	FBbt:00100206	FlyBase:FBrf0224194
+FBbt:00051031	rLAv	ventral	lamina	FBbt:00003708	FBbt:00100206	FlyBase:FBrf0224194
+FBbt:00051032	rLOa	anterior	lobula	FBbt:00003852	FBbt:00100207	FlyBase:FBrf0224194
+FBbt:00051033	rLOd	dorsal	lobula	FBbt:00003852	FBbt:00100207	FlyBase:FBrf0224194
+FBbt:00051034	rLOp	posterior	lobula	FBbt:00003852	FBbt:00100207	FlyBase:FBrf0224194
+FBbt:00051035	rLOPd	dorsal	lobula plate	FBbt:00003885	FBbt:00001948	FlyBase:FBrf0224194
+FBbt:00051036	rLOPp	posterior	lobula plate	FBbt:00003885	FBbt:00001948	FlyBase:FBrf0224194
+FBbt:00051037	rLOPv	ventral	lobula plate	FBbt:00003885	FBbt:00001948	FlyBase:FBrf0224194
+FBbt:00051038	rLOv	ventral	lobula	FBbt:00003852	FBbt:00100207	FlyBase:FBrf0224194
+FBbt:00051039	rMEa	anterior	medulla	FBbt:00003748	FBbt:00100205	FlyBase:FBrf0224194
+FBbt:00051040	rMEd	dorsal	medulla	FBbt:00003748	FBbt:00100205	FlyBase:FBrf0224194
+FBbt:00051041	rMEl	lateral	medulla	FBbt:00003748	FBbt:00100205	FlyBase:FBrf0224194
+FBbt:00051042	rMEp	posterior	medulla	FBbt:00003748	FBbt:00100205	FlyBase:FBrf0224194
+FBbt:00051043	rMEv	ventral	medulla	FBbt:00003748	FBbt:00100205	FlyBase:FBrf0224194

--- a/src/patterns/dosdp_workshop/CBR_subregions/CBRs_nosecondpart.yaml
+++ b/src/patterns/dosdp_workshop/CBR_subregions/CBRs_nosecondpart.yaml
@@ -1,0 +1,57 @@
+pattern_name: Cell_Body_Rind_Subregions
+description: for creating subregions of CBRs from Ito et al. (2014) BrainName paper, where these are not part of a different type of rind.
+
+classes:
+  thing: owl:Thing
+  cell_body_rind_region: FBbt:00100200
+
+relations:
+  part_of: BFO:0000050
+  continuous_with: RO:0002150
+
+vars:
+  position: thing
+  neuropil_name: thing
+  neuropil_id: thing
+  superrind_id: thing
+  abbreviation: thing
+
+
+data_list_vars:
+  def_dbxref: xsd:string
+
+name:
+  text: "cell body rind of adult %s %s"
+  vars:
+    - position
+    - neuropil_name
+
+def:
+  text: "Adult cell body rind region that overlies the %s part of the %s (Ito et al., 2014)."
+  vars:
+    - position
+    - neuropil_name
+  xrefs: def_dbxref
+
+generated_synonyms:
+  -
+    exact_synonym:
+    text: "%s"
+    vars:
+      - abbreviation
+    xrefs: def_dbxref
+    
+logical_axioms:
+  - 
+    axiom_type: subClassOf
+    text: "'part_of' some %s"
+    vars:
+      - superrind_id
+  - 
+    axiom_type: subClassOf
+    text: "'continuous_with' some %s"
+    vars:
+      - neuropil_id
+  - 
+    axiom_type: subClassOf
+    text: "'cell_body_rind_region'"

--- a/src/patterns/dosdp_workshop/CBR_subregions/prefix.yaml
+++ b/src/patterns/dosdp_workshop/CBR_subregions/prefix.yaml
@@ -1,0 +1,3 @@
+FBbt: http://purl.obolibrary.org/obo/FBbt_
+BFO: http://purl.obolibrary.org/obo/BFO_
+RO: http://purl.obolibrary.org/obo/RO_

--- a/src/patterns/dosdp_workshop/terminal_commands.txt
+++ b/src/patterns/dosdp_workshop/terminal_commands.txt
@@ -4,15 +4,14 @@
 cd ~/git/drosophila-anatomy-developmental-ontology/src/patterns/dosdp_workshop/
 
 #generate terms
-dosdp-tools generate --obo-prefixes --prefixes=prefix.yaml --infile=fillers.csv --template=pattern.yaml --ontology=fbbt-edit-copy.obo --outfile=new_terms.obo
-
+dosdp-tools generate --obo-prefixes --prefixes=prefix.yaml --infile=fillers.csv --template=pattern.yaml --ontology=fbbt-edit-copy.obo --outfile=new_terms.owl
 
 #copy to ontology folder:
-cp new_terms.obo ~/git/drosophila-anatomy-developmental-ontology/src/ontology/
+cp new_terms.owl ~/git/drosophila-anatomy-developmental-ontology/src/ontology/
 
 #navigate to ontology folder and merge this with fbbt-edit (without merging fbbt imports):
 cd ~/git/drosophila-anatomy-developmental-ontology/src/ontology/
 
-robot merge --collapse-import-closure false --input fbbt-edit.obo --input new_terms.obo --output merge.obo
+robot merge --collapse-import-closure false --input fbbt-edit.obo --input new_terms.owl --output merge.obo
 
 #check diff with fbbt-edit, then rename to fbbt-edit when satisfied and commit


### PR DESCRIPTION
Added several new CBRs and subregions listed in Ito et al. (2014) Brain Name paper.
CBRs of ganglia and neuromeres now part of those regions (but not neuropil).
Some renames (mostly to add stage).
Optic lobe neurons now defined by soma location (developmentally belong to the optic lobe).

fixes #344