### PR TITLE
Fix running FlyBase imports on M1 machines.

### DIFF
--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -149,7 +149,8 @@ pre_release: $(ONT)-edit.obo tmp/auto_generated_definitions_dot.owl tmp/auto_gen
 all_imports: $(IMPORT_FILES) components/flybase_import.owl
 
 tmp/FBgn_template.tsv: $(IMPORTSEED)
-	if [ $(IMP) = true ]; then python3 -m pip install -r ../scripts/flybase_import/requirements.txt &&\
+	if [ $(IMP) = true ]; then apt-get install -y python3-psycopg2 && \
+	python3 -m pip install -r ../scripts/flybase_import/requirements.txt && \
 	python3 ../scripts/flybase_import/FB_import_runner.py $(IMPORTSEED) $@; fi
 	
 components/flybase_import.owl: tmp/FBgn_template.tsv

--- a/src/scripts/flybase_import/requirements.txt
+++ b/src/scripts/flybase_import/requirements.txt
@@ -1,2 +1,1 @@
 pandas
-psycopg2-binary


### PR DESCRIPTION
FlyBase imports use a Python script that requires psycopg2, which is not
present in the ODK container. It is normally installed through pip prior
to running the script, but on M1-powered machines this does not work
because as of now there is no pre-compiled binary package targeting the
arm64 architecture for psycopg2 in the PYPI repository.

The workaround here is to install psycopg2 through the underlying Ubuntu
distribution (which does provide a arm64 binary package for psycopg2)
via apt-get rather than through pip.

This allows running the import script on M1-powered machines and it
should not change anything for folks using Intel-powered ones.