### PR TITLE
Add a spellchecking step to the release process

### DIFF
--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -10,7 +10,8 @@ DATE   ?= $(shell date +%Y-%m-%d)
 ######################################################
 
 # Illegal division by 0 problem: reports/onto_metrics_calc.txt 
-REPORT_FILES := $(REPORT_FILES) reports/obo_track_new_simple.txt  reports/robot_simple_diff.txt
+REPORT_FILES := $(REPORT_FILES) reports/obo_track_new_simple.txt  reports/robot_simple_diff.txt \
+		reports/spellcheck.txt
 
 SIMPLE_PURL =	http://purl.obolibrary.org/obo/fbbt/fbbt-simple.obo
 LAST_DEPLOYED_SIMPLE=tmp/$(ONT)-simple-last.obo
@@ -20,10 +21,13 @@ $(LAST_DEPLOYED_SIMPLE):
 
 obo_model=https://raw.githubusercontent.com/FlyBase/flybase-controlled-vocabulary/master/external_tools/perl_modules/releases/OboModel.pm
 flybase_script_base=https://raw.githubusercontent.com/FlyBase/drosophila-anatomy-developmental-ontology/master/tools/release_and_checking_scripts/releases/
+flybase_ontology_script_base=https://raw.githubusercontent.com/FlyBase/flybase-ontology-scripts/master/
 onto_metrics_calc=$(flybase_script_base)onto_metrics_calc.pl
 chado_load_checks=$(flybase_script_base)chado_load_checks.pl
 obo_track_new=$(flybase_script_base)obo_track_new.pl
 auto_def_sub=$(flybase_script_base)auto_def_sub.pl
+spellchecker=$(flybase_ontology_script_base)misc/obo_spellchecker.py
+fetch_authors=$(flybase_ontology_script_base)misc/fetch_flybase_authors.py
 
 export PERL5LIB := ${realpath ../scripts}
 install_flybase_scripts:
@@ -32,6 +36,8 @@ install_flybase_scripts:
 	wget -O ../scripts/chado_load_checks.pl $(chado_load_checks) && chmod +x ../scripts/chado_load_checks.pl
 	wget -O ../scripts/obo_track_new.pl $(obo_track_new) && chmod +x ../scripts/obo_track_new.pl
 	wget -O ../scripts/auto_def_sub.pl $(auto_def_sub) && chmod +x ../scripts/auto_def_sub.pl
+	wget -O ../scripts/obo_spellchecker.py $(spellchecker) && chmod +x ../scripts/obo_spellchecker.py
+	wget -O ../scripts/fetch_authors.py $(fetch_authors) && chmod +x ../scripts/fetch_authors.py
 	echo "Warning: Chado load checks currently exclude ISBN wellformedness checks!"
 
 reports/obo_track_new_simple.txt: $(LAST_DEPLOYED_SIMPLE) install_flybase_scripts $(ONT)-simple.obo
@@ -45,6 +51,14 @@ reports/onto_metrics_calc.txt: $(ONT)-simple.obo install_flybase_scripts
 	
 reports/chado_load_check_simple.txt: install_flybase_scripts fly_anatomy.obo 
 	../scripts/chado_load_checks.pl fly_anatomy.obo > $@
+
+reports/spellcheck.txt: fbbt-simple.obo install_flybase_scripts ../../tools/dictionaries/standard.dict
+	sed -nre 's/^# pypi-requirements: //p' ../scripts/obo_spellchecker.py ../scripts/fetch_authors.py \
+		| xargs python -m pip install
+	../scripts/obo_spellchecker.py -o $@ \
+		-d ../../tools/dictionaries/standard.dict \
+		-d '|../scripts/fetch_authors.py' \
+		fbbt-simple.obo
 
 all_reports: all_reports_onestep $(REPORT_FILES)
 

--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -53,6 +53,7 @@ reports/chado_load_check_simple.txt: install_flybase_scripts fly_anatomy.obo
 	../scripts/chado_load_checks.pl fly_anatomy.obo > $@
 
 reports/spellcheck.txt: fbbt-simple.obo install_flybase_scripts ../../tools/dictionaries/standard.dict
+	if [ `uname -m` = aarch64 ] ; then apt-get install -y python3-psycopg2 ; fi
 	sed -nre 's/^# pypi-requirements: //p' ../scripts/obo_spellchecker.py ../scripts/fetch_authors.py \
 		| xargs python -m pip install
 	../scripts/obo_spellchecker.py -o $@ \

--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -53,7 +53,7 @@ reports/chado_load_check_simple.txt: install_flybase_scripts fly_anatomy.obo
 	../scripts/chado_load_checks.pl fly_anatomy.obo > $@
 
 reports/spellcheck.txt: fbbt-simple.obo install_flybase_scripts ../../tools/dictionaries/standard.dict
-	if [ `uname -m` = aarch64 ] ; then apt-get install -y python3-psycopg2 ; fi
+	apt-get install -y python3-psycopg2
 	sed -nre 's/^# pypi-requirements: //p' ../scripts/obo_spellchecker.py ../scripts/fetch_authors.py \
 		| xargs python -m pip install
 	../scripts/obo_spellchecker.py -o $@ \

--- a/src/ontology/reports/spellcheck.txt
+++ b/src/ontology/reports/spellcheck.txt
@@ -1,23 +1,20 @@
+Term: lamellocyte (FBbt:00001687)
+In definition: atilla
+
+Term: paraesophageal ganglion (FBbt:00002635)
+In synonyms: paraoesophageal
+
 Term: dorsal organ (FBbt:00002655)
 In synonyms: antso
 
 Term: dorsolateral papilla (FBbt:00002679)
-In synonyms: pmod
+In synonyms: papillum pmod
 
-Term: adult protocerebral bridge 1 glomerulus-fan-shaped body-lateral accessory lobe neuron (FBbt:00003635)
-In synonyms: idfp
+Term: campaniform sensillum of distal group (FBbt:00002692)
+In synonyms: papillum
 
-Term: lamellocyte (FBbt:00001687)
-In definition: atilla
-
-Term: optic lobe pioneer neuron 1 (FBbt:00003704)
-In synonyms: chalv
-
-Term: optic lobe pioneer neuron 2 (FBbt:00003705)
-In synonyms: glulv
-
-Term: adult cervical connective (FBbt:00004019)
-In synonyms: cvcon
+Term: ventral organ (FBbt:00002707)
+In synonyms: ventrales
 
 Term: tibial depressor muscle (FBbt:00003322)
 In synonyms: tidm
@@ -37,8 +34,20 @@ In synonyms: talm
 Term: femoral reductor muscle (FBbt:00003332)
 In synonyms: ferm
 
+Term: adult protocerebral bridge 1 glomerulus-fan-shaped body-lateral accessory lobe neuron (FBbt:00003635)
+In synonyms: idfp
+
+Term: optic lobe pioneer neuron 1 (FBbt:00003704)
+In synonyms: chalv
+
+Term: optic lobe pioneer neuron 2 (FBbt:00003705)
+In synonyms: glulv
+
+Term: adult cervical connective (FBbt:00004019)
+In synonyms: cvcon
+
 Term: adult ventral nerve cord (FBbt:00004052)
-In synonyms: thgng thoracicoabdominal
+In synonyms: thgng
 
 Term: adult dorsal prothoracic nerve (FBbt:00004055)
 In synonyms: dpron
@@ -78,21 +87,6 @@ In synonyms: trfaf
 
 Term: prothoracic trochanter campaniform sensillum Sc13 (FBbt:00004264)
 In synonyms: trff
-
-Term: cyst progenitor cell (FBbt:00004933)
-In synonyms: cysc
-
-Term: eyelet photoreceptor (FBbt:00005740)
-In synonyms: hbeyelet
-
-Term: Pcd2 neuroblast (FBbt:00005865)
-In synonyms: mbnbd
-
-Term: Pcd4 neuroblast (FBbt:00005867)
-In synonyms: mbnbb
-
-Term: Pcd9 neuroblast (FBbt:00005879)
-In synonyms: mbnbc
 
 Term: prothoracic femoral campaniform sensillum Sc1 (FBbt:00004276)
 In synonyms: fesf
@@ -136,8 +130,32 @@ In synonyms: fesr
 Term: metathoracic femoral campaniform sensillum Sc11 (FBbt:00004444)
 In synonyms: fefr
 
+Term: cyst progenitor cell (FBbt:00004933)
+In synonyms: cysc
+
 Term: amnioserosa anlage in statu nascendi (FBbt:00005422)
 In synonyms: amnioser
+
+Term: eyelet photoreceptor (FBbt:00005740)
+In synonyms: hbeyelet
+
+Term: Pcd2 neuroblast (FBbt:00005865)
+In synonyms: mbnbd
+
+Term: Pcd4 neuroblast (FBbt:00005867)
+In synonyms: mbnbb
+
+Term: Pcd9 neuroblast (FBbt:00005879)
+In synonyms: mbnbc
+
+Term: Pcv9 neuroblast (FBbt:00006006)
+In synonyms: mbnba
+
+Term: adult prothoracic leg nerve (FBbt:00007657)
+In synonyms: proln
+
+Term: tectulum (FBbt:00007727)
+In synonyms: tect
 
 Term: abdominal dorso-lateral adult muscle precursor cell (FBbt:00013243)
 In synonyms: dlap
@@ -166,51 +184,6 @@ In synonyms: amnioser
 Term: gorget (FBbt:00040039)
 In synonyms: vmcs
 
-Term: lineage MNB primary neuron (FBbt:00048864)
-In synonyms: mnbp
-
-Term: adult lateral accessory lobe-ipsilateral nodulus 2 neuron (FBbt:00049136)
-In synonyms: crel
-
-Term: adult lateral accessory lobe-anterior nodulus 3 neuron (FBbt:00049137)
-In synonyms: lnoa
-
-Term: adult lateral accessory lobe-crepine-posterior and medial nodulus 3 neuron (FBbt:00049138)
-In synonyms: lcnpm lcnopm
-
-Term: adult lateral accessory lobe-crepine-posterior nodulus 3 neuron (FBbt:00049139)
-In synonyms: lcnop lcnp crec
-
-Term: adult bilateral superior lateral protocerebrum-asymmetrical body neuron (FBbt:00049143)
-In synonyms: abic
-
-Term: adult superior lateral protocerebrum-asymmetrical body-fan-shaped body layer 8 neuron (FBbt:00049145)
-In synonyms: slpaf
-
-Term: Pcv9 neuroblast (FBbt:00006006)
-In synonyms: mbnba
-
-Term: adult intrinsic lateral accessory lobe neuron (FBbt:00048092)
-In synonyms: vbos
-
-Term: vertical system-like neuron (FBbt:00048128)
-In synonyms: vslike
-
-Term: adult prothoracic leg nerve (FBbt:00007657)
-In synonyms: proln
-
-Term: tectulum (FBbt:00007727)
-In synonyms: tect
-
-Term: larval rectal sphincter (FBbt:00048236)
-In synonyms: auns
-
-Term: hypandrial phragma (FBbt:00048385)
-In synonyms: fragma
-
-Term: adult prothoracic chordotonal nerve (FBbt:00049893)
-In synonyms: procn
-
 Term: superior posterior slope (FBbt:00045040)
 In synonyms: vmcpod
 
@@ -229,6 +202,65 @@ In synonyms: wtct
 Term: haltere neuropil (FBbt:00047138)
 In synonyms: htct
 
+Term: neck neuropil (FBbt:00047173)
+In synonyms: ntct
+
+Term: adult mesothoracic anterior anterior ventral commissure (FBbt:00047548)
+In synonyms: mesoth
+
+Term: adult metathoracic anterior anterior ventral commissure (FBbt:00047550)
+In synonyms: metath
+
+Term: adult intrinsic lateral accessory lobe neuron (FBbt:00048092)
+In synonyms: vbos
+
+Term: vertical system-like neuron (FBbt:00048128)
+In synonyms: vslike
+
+Term: larval rectal sphincter (FBbt:00048236)
+In synonyms: auns
+
+Term: hypandrial phragma (FBbt:00048385)
+In synonyms: fragma
+
+Term: larval anterior central sensory compartment anterior medial region (FBbt:00048492)
+In synonyms: acscam
+
+Term: larval anterior ventral sensory compartment posterior region (FBbt:00048494)
+In synonyms: avscp
+
+Term: larval anterior central sensory compartment anterior lateral region (FBbt:00048495)
+In comment: acscal
+In synonyms: acscal
+
+Term: larval anterior central sensory compartment posterior region (FBbt:00048496)
+In comment: acscal acscp
+In synonyms: acscal acscp
+
+Term: larval A03x neuron (FBbt:00048632)
+In synonyms: eghb
+
+Term: lineage MNB primary neuron (FBbt:00048864)
+In synonyms: mnbp
+
+Term: adult lateral accessory lobe-ipsilateral nodulus 2 neuron (FBbt:00049136)
+In synonyms: crel
+
+Term: adult lateral accessory lobe-anterior nodulus 3 neuron (FBbt:00049137)
+In synonyms: lnoa
+
+Term: adult lateral accessory lobe-crepine-posterior and medial nodulus 3 neuron (FBbt:00049138)
+In synonyms: lcnopm lcnpm
+
+Term: adult lateral accessory lobe-crepine-posterior nodulus 3 neuron (FBbt:00049139)
+In synonyms: crec lcnop lcnp
+
+Term: adult bilateral superior lateral protocerebrum-asymmetrical body neuron (FBbt:00049143)
+In synonyms: abic
+
+Term: adult superior lateral protocerebrum-asymmetrical body-fan-shaped body layer 8 neuron (FBbt:00049145)
+In synonyms: slpaf
+
 Term: adult ellipsoid body-dorsal gall surround neuron (FBbt:00049180)
 In synonyms: ebgas
 
@@ -244,40 +276,23 @@ In synonyms: prodob
 Term: adult lateral horn AV1a1 neuron (FBbt:00049331)
 In synonyms: vlpn
 
-Term: larval anterior central sensory compartment anterior medial region (FBbt:00048492)
-In synonyms: acscam
+Term: gamma-s Kenyon cell (FBbt:00049830)
+In synonyms: kcgammas
 
-Term: larval anterior ventral sensory compartment posterior region (FBbt:00048494)
-In synonyms: avscp
+Term: gamma-t Kenyon cell (FBbt:00049833)
+In synonyms: kcgammat
 
-Term: larval anterior central sensory compartment anterior lateral region (FBbt:00048495)
-In comment: acscal
-In synonyms: acscal
+Term: alpha/beta surface/core Kenyon cell (FBbt:00049838)
+In synonyms: betasc
 
-Term: larval anterior central sensory compartment posterior region (FBbt:00048496)
-In comment: acscp acscal
-In synonyms: acscal acscp
-
-Term: larval A03x neuron (FBbt:00048632)
-In synonyms: eghb
-
-Term: neck neuropil (FBbt:00047173)
-In synonyms: ntct
+Term: adult prothoracic chordotonal nerve (FBbt:00049893)
+In synonyms: procn
 
 Term: small unit of anterior optic tubercle (FBbt:00051217)
 In synonyms: aotusu
 
 Term: larval mushroom body non-intrinsic type 2 neuron (FBbt:00051367)
 In definition: mbnba
-
-Term: adult mesothoracic anterior anterior ventral commissure (FBbt:00047548)
-In synonyms: mesoth
-
-Term: adult metathoracic anterior anterior ventral commissure (FBbt:00047550)
-In synonyms: metath
-
-Term: mushroom body beta' middle layer (FBbt:00100270)
-In synonyms: betam
 
 Term: prothoracic tibial campaniform sensillum Sc2 (FBbt:00058049)
 In synonyms: tigdf
@@ -309,20 +324,35 @@ In synonyms: tirm
 Term: tarsal reductor muscle (FBbt:00058113)
 In synonyms: tarm
 
-Term: lateral VUM motor neuron (FBbt:00110308)
-In synonyms: vumsn
+Term: mushroom body beta' middle layer (FBbt:00100270)
+In synonyms: betam
 
 Term: adult abdominal neuromere (FBbt:00110173)
 In synonyms: abgng
 
+Term: lateral VUM motor neuron (FBbt:00110308)
+In synonyms: vumsn
+
 Term: posterior tooth bristle of antennal segment 2 (FBbt:00110820)
 In synonyms: zahnborsten
+
+Term: alpha/beta posterior Kenyon cell (FBbt:00110931)
+In synonyms: kcalpha
+
+Term: gamma dorsal Kenyon cell (FBbt:00110932)
+In synonyms: gammad
+
+Term: gamma main Kenyon cell (FBbt:00111061)
+In synonyms: gammamain
+
+Term: larval Goro neuron (FBbt:00111240)
+In synonyms: gorogoro
 
 Term: adult lateral accessory lobe-posterior slope-protocerebral bridge neuron (FBbt:00111382)
 In synonyms: lpsp lpsp
 
 Term: adult inferior bridge-superior posterior slope-protocerebral bridge neuron (FBbt:00111383)
-In synonyms: ibspsp ibspsp ibsps
+In synonyms: ibsps ibspsp ibspsp
 
 Term: protocerebral bridge 1 glomerulus-fan-shaped body-nodulus 2 dorsal domain neuron (FBbt:00111390)
 In comment: pfnd
@@ -355,25 +385,4 @@ In synonyms: spsi spsp
 
 Term: median neuroblast MNB interneuron (FBbt:00111616)
 In synonyms: mnbp
-
-Term: alpha/beta posterior Kenyon cell (FBbt:00110931)
-In synonyms: kcalpha
-
-Term: gamma dorsal Kenyon cell (FBbt:00110932)
-In synonyms: gammad
-
-Term: gamma main Kenyon cell (FBbt:00111061)
-In synonyms: gammamain
-
-Term: larval Goro neuron (FBbt:00111240)
-In synonyms: gorogoro
-
-Term: gamma-s Kenyon cell (FBbt:00049830)
-In synonyms: kcgammas
-
-Term: gamma-t Kenyon cell (FBbt:00049833)
-In synonyms: kcgammat
-
-Term: alpha/beta surface/core Kenyon cell (FBbt:00049838)
-In synonyms: betasc
 

--- a/src/ontology/reports/spellcheck.txt
+++ b/src/ontology/reports/spellcheck.txt
@@ -1,0 +1,379 @@
+Term: dorsal organ (FBbt:00002655)
+In synonyms: antso
+
+Term: dorsolateral papilla (FBbt:00002679)
+In synonyms: pmod
+
+Term: adult protocerebral bridge 1 glomerulus-fan-shaped body-lateral accessory lobe neuron (FBbt:00003635)
+In synonyms: idfp
+
+Term: lamellocyte (FBbt:00001687)
+In definition: atilla
+
+Term: optic lobe pioneer neuron 1 (FBbt:00003704)
+In synonyms: chalv
+
+Term: optic lobe pioneer neuron 2 (FBbt:00003705)
+In synonyms: glulv
+
+Term: adult cervical connective (FBbt:00004019)
+In synonyms: cvcon
+
+Term: tibial depressor muscle (FBbt:00003322)
+In synonyms: tidm
+
+Term: tarsal depressor muscle (FBbt:00003323)
+In synonyms: tadm
+
+Term: intracoxal levator muscle (FBbt:00003326)
+In synonyms: trlm
+
+Term: tibial levator muscle (FBbt:00003329)
+In synonyms: tilm
+
+Term: tarsal levator muscle (FBbt:00003330)
+In synonyms: talm
+
+Term: femoral reductor muscle (FBbt:00003332)
+In synonyms: ferm
+
+Term: adult ventral nerve cord (FBbt:00004052)
+In synonyms: thgng thoracicoabdominal
+
+Term: adult dorsal prothoracic nerve (FBbt:00004055)
+In synonyms: dpron
+
+Term: adult prothoracic accessory nerve (FBbt:00004056)
+In synonyms: proan
+
+Term: adult mesothoracic leg nerve (FBbt:00004063)
+In synonyms: mesoln
+
+Term: direct flight muscle motor neuron (FBbt:00004065)
+In synonyms: dfmmn
+
+Term: adult accessory mesothoracic neuropil (FBbt:00004091)
+In synonyms: amnp
+
+Term: adult dorsal metathoracic nerve (FBbt:00004094)
+In synonyms: dmetan
+
+Term: adult metathoracic leg nerve (FBbt:00004096)
+In synonyms: metaln
+
+Term: adult abdominal nerve trunk (FBbt:00004099)
+In synonyms: abnt
+
+Term: proximal rostral sensillum (FBbt:00004169)
+In synonyms: prst
+
+Term: prothoracic trochanter campaniform sensillum Sc-8 (FBbt:00004261)
+In synonyms: trfpf
+
+Term: prothoracic trochanter campaniform sensillum Sc3 (FBbt:00004262)
+In synonyms: trgf
+
+Term: prothoracic trochanter campaniform sensillum Sc+5 (FBbt:00004263)
+In synonyms: trfaf
+
+Term: prothoracic trochanter campaniform sensillum Sc13 (FBbt:00004264)
+In synonyms: trff
+
+Term: cyst progenitor cell (FBbt:00004933)
+In synonyms: cysc
+
+Term: eyelet photoreceptor (FBbt:00005740)
+In synonyms: hbeyelet
+
+Term: Pcd2 neuroblast (FBbt:00005865)
+In synonyms: mbnbd
+
+Term: Pcd4 neuroblast (FBbt:00005867)
+In synonyms: mbnbb
+
+Term: Pcd9 neuroblast (FBbt:00005879)
+In synonyms: mbnbc
+
+Term: prothoracic femoral campaniform sensillum Sc1 (FBbt:00004276)
+In synonyms: fesf
+
+Term: prothoracic femoral campaniform sensillum Sc11 (FBbt:00004277)
+In synonyms: feff
+
+Term: mesothoracic trochanter campaniform sensillum Sc-8 (FBbt:00004370)
+In synonyms: trfpm
+
+Term: mesothoracic trochanter campaniform sensillum Sc3 (FBbt:00004371)
+In synonyms: trgm
+
+Term: mesothoracic trochanter campaniform sensillum Sc+5 (FBbt:00004372)
+In synonyms: trfam
+
+Term: mesothoracic trochanter campaniform sensillum Sc13 (FBbt:00004373)
+In synonyms: trfm
+
+Term: mesothoracic femoral campaniform sensillum Sc1 (FBbt:00004385)
+In synonyms: fesm
+
+Term: mesothoracic femoral campaniform sensillum Sc11 (FBbt:00004386)
+In synonyms: fefm
+
+Term: metathoracic trochanter campaniform sensillum Sc-8 (FBbt:00004428)
+In synonyms: trfpr
+
+Term: metathoracic trochanter campaniform sensillum Sc3 (FBbt:00004429)
+In synonyms: trgr
+
+Term: metathoracic trochanter campaniform sensillum Sc+5 (FBbt:00004430)
+In synonyms: trfar
+
+Term: metathoracic trochanter campaniform sensillum Sc13 (FBbt:00004431)
+In synonyms: trfr
+
+Term: metathoracic femoral campaniform sensillum Sc1 (FBbt:00004443)
+In synonyms: fesr
+
+Term: metathoracic femoral campaniform sensillum Sc11 (FBbt:00004444)
+In synonyms: fefr
+
+Term: amnioserosa anlage in statu nascendi (FBbt:00005422)
+In synonyms: amnioser
+
+Term: abdominal dorso-lateral adult muscle precursor cell (FBbt:00013243)
+In synonyms: dlap
+
+Term: dorsolateral domain of larval labial neuromere (FBbt:00015023)
+In synonyms: lbdl
+
+Term: dorsolateral domain of larval mandibular neuromere (FBbt:00015030)
+In synonyms: mddl
+
+Term: dorsomedial domain of larval mandibular neuromere (FBbt:00015031)
+In synonyms: mddm
+
+Term: dorsolateral domain of larval maxillary neuromere (FBbt:00015037)
+In synonyms: mxdl
+
+Term: salivary gland common duct primordium (FBbt:00016005)
+In synonyms: salcd
+
+Term: adult salivary gland anlage (FBbt:00016006)
+In synonyms: adsal
+
+Term: amnioserosa anlage (FBbt:00017017)
+In synonyms: amnioser
+
+Term: gorget (FBbt:00040039)
+In synonyms: vmcs
+
+Term: lineage MNB primary neuron (FBbt:00048864)
+In synonyms: mnbp
+
+Term: adult lateral accessory lobe-ipsilateral nodulus 2 neuron (FBbt:00049136)
+In synonyms: crel
+
+Term: adult lateral accessory lobe-anterior nodulus 3 neuron (FBbt:00049137)
+In synonyms: lnoa
+
+Term: adult lateral accessory lobe-crepine-posterior and medial nodulus 3 neuron (FBbt:00049138)
+In synonyms: lcnpm lcnopm
+
+Term: adult lateral accessory lobe-crepine-posterior nodulus 3 neuron (FBbt:00049139)
+In synonyms: lcnop lcnp crec
+
+Term: adult bilateral superior lateral protocerebrum-asymmetrical body neuron (FBbt:00049143)
+In synonyms: abic
+
+Term: adult superior lateral protocerebrum-asymmetrical body-fan-shaped body layer 8 neuron (FBbt:00049145)
+In synonyms: slpaf
+
+Term: Pcv9 neuroblast (FBbt:00006006)
+In synonyms: mbnba
+
+Term: adult intrinsic lateral accessory lobe neuron (FBbt:00048092)
+In synonyms: vbos
+
+Term: vertical system-like neuron (FBbt:00048128)
+In synonyms: vslike
+
+Term: adult prothoracic leg nerve (FBbt:00007657)
+In synonyms: proln
+
+Term: tectulum (FBbt:00007727)
+In synonyms: tect
+
+Term: larval rectal sphincter (FBbt:00048236)
+In synonyms: auns
+
+Term: hypandrial phragma (FBbt:00048385)
+In synonyms: fragma
+
+Term: adult prothoracic chordotonal nerve (FBbt:00049893)
+In synonyms: procn
+
+Term: superior posterior slope (FBbt:00045040)
+In synonyms: vmcpod
+
+Term: inferior posterior slope (FBbt:00045046)
+In synonyms: vmcpov
+
+Term: fat cell (FBbt:00046052)
+In comment: apollp
+
+Term: adult prothoracic anterior anterior ventral commissure (FBbt:00047133)
+In synonyms: proth
+
+Term: wing neuropil (FBbt:00047137)
+In synonyms: wtct
+
+Term: haltere neuropil (FBbt:00047138)
+In synonyms: htct
+
+Term: adult ellipsoid body-dorsal gall surround neuron (FBbt:00049180)
+In synonyms: ebgas
+
+Term: dorsal protractor muscle (FBbt:00049189)
+In synonyms: prodo
+
+Term: dorsal protractor muscle A (FBbt:00049190)
+In synonyms: prodoa
+
+Term: dorsal protractor muscle B (FBbt:00049191)
+In synonyms: prodob
+
+Term: adult lateral horn AV1a1 neuron (FBbt:00049331)
+In synonyms: vlpn
+
+Term: larval anterior central sensory compartment anterior medial region (FBbt:00048492)
+In synonyms: acscam
+
+Term: larval anterior ventral sensory compartment posterior region (FBbt:00048494)
+In synonyms: avscp
+
+Term: larval anterior central sensory compartment anterior lateral region (FBbt:00048495)
+In comment: acscal
+In synonyms: acscal
+
+Term: larval anterior central sensory compartment posterior region (FBbt:00048496)
+In comment: acscp acscal
+In synonyms: acscal acscp
+
+Term: larval A03x neuron (FBbt:00048632)
+In synonyms: eghb
+
+Term: neck neuropil (FBbt:00047173)
+In synonyms: ntct
+
+Term: small unit of anterior optic tubercle (FBbt:00051217)
+In synonyms: aotusu
+
+Term: larval mushroom body non-intrinsic type 2 neuron (FBbt:00051367)
+In definition: mbnba
+
+Term: adult mesothoracic anterior anterior ventral commissure (FBbt:00047548)
+In synonyms: mesoth
+
+Term: adult metathoracic anterior anterior ventral commissure (FBbt:00047550)
+In synonyms: metath
+
+Term: mushroom body beta' middle layer (FBbt:00100270)
+In synonyms: betam
+
+Term: prothoracic tibial campaniform sensillum Sc2 (FBbt:00058049)
+In synonyms: tigdf
+
+Term: prothoracic tibial campaniform sensillum Sc3 (FBbt:00058050)
+In synonyms: tigvf
+
+Term: mesothoracic tibial campaniform sensillum Sc3 (FBbt:00058055)
+In synonyms: tigvm
+
+Term: mesothoracic tibial campaniform sensillum Sc2 (FBbt:00058056)
+In synonyms: tigdm
+
+Term: metathoracic tibial campaniform sensillum Sc3 (FBbt:00058059)
+In synonyms: tigvr
+
+Term: metathoracic tibial campaniform sensillum Sc2 (FBbt:00058060)
+In synonyms: tigdr
+
+Term: trochanter reductor muscle (FBbt:00058101)
+In synonyms: trrm
+
+Term: femoral depressor muscle (FBbt:00058105)
+In synonyms: fedm
+
+Term: tibial reductor muscle (FBbt:00058109)
+In synonyms: tirm
+
+Term: tarsal reductor muscle (FBbt:00058113)
+In synonyms: tarm
+
+Term: lateral VUM motor neuron (FBbt:00110308)
+In synonyms: vumsn
+
+Term: adult abdominal neuromere (FBbt:00110173)
+In synonyms: abgng
+
+Term: posterior tooth bristle of antennal segment 2 (FBbt:00110820)
+In synonyms: zahnborsten
+
+Term: adult lateral accessory lobe-posterior slope-protocerebral bridge neuron (FBbt:00111382)
+In synonyms: lpsp lpsp
+
+Term: adult inferior bridge-superior posterior slope-protocerebral bridge neuron (FBbt:00111383)
+In synonyms: ibspsp ibspsp ibsps
+
+Term: protocerebral bridge 1 glomerulus-fan-shaped body-nodulus 2 dorsal domain neuron (FBbt:00111390)
+In comment: pfnd
+In synonyms: pfnd
+
+Term: protocerebral bridge 1 glomerulus-fan-shaped body-nodulus 3 anterior domain neuron (FBbt:00111396)
+In comment: pfna
+In synonyms: pfna
+
+Term: protocerebral bridge 1 glomerulus-fan-shaped body-nodulus 3 posterior domain neuron (FBbt:00111404)
+In comment: pfnp
+In synonyms: pfnp
+
+Term: adult ellipsoid body-protocerebral bridge glomerulus 9-gall tip neuron (FBbt:00111423)
+In synonyms: epgt
+
+Term: protocerebral bridge 1 glomerulus-fan-shaped body layer 2-lateral accessory lobe-crepine neuron (FBbt:00111433)
+In synonyms: lcre
+
+Term: protocerebral bridge 1 glomerulus-fan-shaped body-nodulus 2 ventral domain neuron (FBbt:00111512)
+In comment: pfnv
+In synonyms: pfnv
+
+Term: protocerebral bridge 1 glomerulus-fan-shaped body-nodulus 3 medial domain neuron (FBbt:00111513)
+In comment: pfnm
+In synonyms: pfnm
+
+Term: adult superior posterior slope-protocerebral bridge neuron (FBbt:00111514)
+In synonyms: spsi spsp
+
+Term: median neuroblast MNB interneuron (FBbt:00111616)
+In synonyms: mnbp
+
+Term: alpha/beta posterior Kenyon cell (FBbt:00110931)
+In synonyms: kcalpha
+
+Term: gamma dorsal Kenyon cell (FBbt:00110932)
+In synonyms: gammad
+
+Term: gamma main Kenyon cell (FBbt:00111061)
+In synonyms: gammamain
+
+Term: larval Goro neuron (FBbt:00111240)
+In synonyms: gorogoro
+
+Term: gamma-s Kenyon cell (FBbt:00049830)
+In synonyms: kcgammas
+
+Term: gamma-t Kenyon cell (FBbt:00049833)
+In synonyms: kcgammat
+
+Term: alpha/beta surface/core Kenyon cell (FBbt:00049838)
+In synonyms: betasc
+

--- a/src/scripts/fetch_authors.py
+++ b/src/scripts/fetch_authors.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# fetch_flybase_authors - Get authors known to FlyBase
+# Copyright © 2021 Damien Goutte-Gattat
+#
+# Redistribution and use of this script, with or without modifications,
+# is permitted provided that the following conditions are met:
+#
+# 1. Redistributions of this script must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# pypi-requirements: psycopg2 click
+
+import sys
+from psycopg2 import connect
+import click
+
+
+def die(msg):
+    print(f"fetch_flybase_authors: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+@click.command(context_settings={'help_option_names': ['-h', '--help']})
+@click.option('--hostname', '-H', default='chado.flybase.org', metavar='HOST',
+              help="""The hostname of the database server (default:
+                      chado.flybase.org).""")
+@click.option('--username', '-u', default='flybase', metavar='USER',
+              help="""The username to connect with (default: flybase).""")
+@click.option('--database', '-d', default='flybase', metavar='NAME',
+              help="""The name of the database (default: flybase).""")
+@click.option('--output', '-o', type=click.File('w'), default=sys.stdout,
+              help="""Write to the specified file instead of standard
+                      output.""")
+def fetch_flybase_authors(hostname, username, database, output):
+    """Get the names of all authors known to FlyBase.
+    
+    This command queries FlyBase to get a sorted list of the surnames
+    of all authors in the database.
+    """
+
+    try:
+        conn = connect(host=hostname, user=username, dbname=database)
+    except Exception as e:
+        die(f"Cannot connect to the database: {e}")
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute('SELECT surname FROM pubauthor;')
+            raw_authors = cur.fetchall()
+    except Exception as e:
+        die(f"Cannot query author names: {e}")
+    finally:
+        conn.close()
+
+    authors = list(set([a[0] for a in raw_authors]))
+    authors.sort()
+
+    output.write('\n'.join(authors))
+
+
+if __name__ == '__main__':
+    fetch_flybase_authors()

--- a/src/scripts/obo_spellchecker.py
+++ b/src/scripts/obo_spellchecker.py
@@ -194,7 +194,7 @@ def check_ontology(obofile, output, dictionary, obsolete):
     checker.add_filter(exclude_all_uppercase_words, pre=True)
     checker.add_filter(exclude_camelcase_words, pre=True)
 
-    for term in onto.terms():
+    for term in sorted(onto.terms()):
         if term.obsolete and not obsolete:
             continue
         r = checker.check_term(term)
@@ -204,7 +204,7 @@ def check_ontology(obofile, output, dictionary, obsolete):
         output.write(f"Term: {term.name} ({term.id})\n")
         for k, v in r.items():
             output.write(f"In {k}: ")
-            output.write(" ".join(v))
+            output.write(" ".join(sorted(v)))
             output.write("\n")
         output.write("\n")
 

--- a/src/scripts/obo_spellchecker.py
+++ b/src/scripts/obo_spellchecker.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# obo-spellchecker - Spellchecker for OBO-formatted ontologies
+# Copyright © 2021 Damien Goutte-Gattat
+#
+# Redistribution and use of this script, with or without modifications,
+# is permitted provided that the following conditions are met:
+#
+# 1. Redistributions of this script must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# pypi-requirements: pronto pyspellchecker click
+
+import sys
+from subprocess import run
+
+from pronto import Ontology
+from spellchecker import SpellChecker
+import click
+
+prog_name = "obo-spellchecker"
+prog_version = "0.1.0"
+prog_notice = f"""\
+{prog_name} {prog_version}
+Copyright © 2021 Damien Goutte-Gattat
+
+This program is released under the terms of the 1-clause BSD licence.
+"""
+
+
+def die(msg):
+    print(f"{prog_name}: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+class OntoChecker(object):
+
+    def __init__(self):
+        self._checker = SpellChecker()
+        self._post_filters = []
+        self._pre_filters = []
+
+    def add_custom_dictionary(self, dictionary):
+        self._checker.word_frequency.load_text(dictionary)
+
+    def add_filter(self, filter_, pre=False):
+        if pre:
+            self._pre_filters.append(filter_)
+        else:
+            self._post_filters.append(filter_)
+
+    def check_term(self, term):
+        n = 0
+        results = {}
+
+        for field in ['name', 'definition', 'comment']:
+            words = self._check_term_field(term, field)
+            if words is not None:
+                n += 1
+                results[field] = words
+
+        words = self._check_term_synonyms(term)
+        if words is not None:
+            n += 1
+            results['synonyms'] = words
+
+        if n > 0:
+            return results
+        else:
+            return None
+
+    def _check_term_field(self, term, field):
+        value = getattr(term, field)
+        if value is None:
+            return None
+
+        words = self._check_value(value)
+        if len(words):
+            return words
+        else:
+            return None
+
+    def _check_term_synonyms(self, term):
+        words = []
+        for synonym in term.synonyms:
+            words.extend(self._check_value(synonym.description))
+
+        if len(words):
+            return words
+        else:
+            return None
+
+    def _check_value(self, value):
+        input_words = self._checker.split_words(value)
+        input_words = [w for w in input_words if not self._apply_filters(w, self._pre_filters)]
+
+        words = self._checker.unknown(input_words)
+        words = [w for w in words if not self._apply_filters(w, self._post_filters)]
+
+        return words
+
+    def _apply_filters(self, word, filters):
+        for f in filters:
+            if f(word):
+                return True
+        return False
+
+
+def exclude_words_with_number(word):
+    return not word.isalpha()
+
+
+def exclude_all_uppercase_words(word):
+    return word.isupper()
+
+
+def exclude_camelcase_words(word):
+    return word[0].islower() and not word[1:].islower()
+
+
+def make_exclude_short_word_filter(threshold):
+
+    def exclude_short_word_filter(word):
+        return len(word) < threshold
+
+    return exclude_short_word_filter
+
+
+def _load_dictionary(location):
+    if location[0] == '|':
+        r = run(location[1:], shell=True, capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"Command failed ({r.returncode})")
+        return r.stdout
+    else:
+        with open(location, 'r') as f:
+            return f.read()
+
+
+@click.command(context_settings={'help_option_names': ['-h', '--help']})
+@click.version_option(version=prog_version, message=prog_notice)
+@click.argument('obofile')
+@click.option('--output', '-o', type=click.File('w'), default=sys.stdout,
+              help="""Write the report to the specified FILE instead
+                      of standard output.""")
+@click.option('--dictionary', '-d', multiple=True, metavar='DICT',
+              help="""Use the specified additional dictionary.
+                      This option may be used multiple times to use
+                      as many additional dictionaries as needed.
+                      If DICT starts with a pipe character ('|'),
+                      it is interpreted as a command that is expected
+                      to write the dictionary to its standard output. """)
+@click.option('--obsolete/--no-obsolete', default=False,
+              help="""Check terms marked as obsolete.""")
+def check_ontology(obofile, output, dictionary, obsolete):
+    """Spell-check the specified OBOFILE.
+    
+    This command performs a spell-check on the ontology in the
+    provided OBO file. For every term defined in the ontology,
+    it looks for misspelled words in the label, the definition,
+    and any comment and synonym.
+    
+    It produces a report listing the misspelled words for each
+    term.
+    """
+
+    try:
+        onto = Ontology(obofile)
+    except Exception as e:
+        die(f"Cannot load ontology: {e}")
+
+    checker = OntoChecker()
+    for dictfile in dictionary:
+        try:
+            dictdata = _load_dictionary(dictfile)
+        except Exception as e:
+            die(f"Cannot load dictionary: {e}")
+        checker.add_custom_dictionary(dictdata)
+
+    checker.add_filter(exclude_words_with_number)
+    checker.add_filter(make_exclude_short_word_filter(4))
+    checker.add_filter(exclude_all_uppercase_words, pre=True)
+    checker.add_filter(exclude_camelcase_words, pre=True)
+
+    for term in onto.terms():
+        if term.obsolete and not obsolete:
+            continue
+        r = checker.check_term(term)
+        if not r:
+            continue
+
+        output.write(f"Term: {term.name} ({term.id})\n")
+        for k, v in r.items():
+            output.write(f"In {k}: ")
+            output.write(" ".join(v))
+            output.write("\n")
+        output.write("\n")
+
+
+if __name__ == '__main__':
+    check_ontology()

--- a/tools/dictionaries/standard.dict
+++ b/tools/dictionaries/standard.dict
@@ -43340,7 +43340,6 @@ paperwork
 papilla
 papillae
 papillar
-papillum
 paprika
 par
 para
@@ -43418,7 +43417,6 @@ paranoia
 paranoid
 paranuclear
 paraocciput
-paraoesophageal
 paraoxon
 paraoxonase
 parapet
@@ -59380,7 +59378,7 @@ thong
 thonged
 thoracic
 thoracico
-thoracoabdominal
+thoracicoabdominal
 thorax
 thorn
 thorn's
@@ -63434,7 +63432,6 @@ ventilations
 ventilative
 venting
 ventral
-ventrales
 ventrally
 ventralmost
 ventricle

--- a/tools/dictionaries/standard.dict
+++ b/tools/dictionaries/standard.dict
@@ -2081,6 +2081,7 @@ Marianne
 Marianne's
 Marin
 Markus
+Márkus
 Marques
 Martinez
 Mary
@@ -2296,7 +2297,6 @@ Myeloblastosis
 MyoD
 Myoinhibiting
 Myxinidae
-Márkus
 N'acyl
 N.B
 N.B.
@@ -2941,6 +2941,7 @@ SecA
 SegTra
 Sehgal
 Sejourne
+Séjourné
 Sel
 SelR
 SelU
@@ -3088,7 +3089,6 @@ Swm
 Sylvius
 Syr
 Sz
-Séjourné
 TAFIIs
 TAFs
 TALENs
@@ -6718,6 +6718,7 @@ antennocerebral
 antennocommissural
 antennoglomerular
 antennomaxillary
+antennoprotocerebral
 antephragme
 anteriodorsal
 anteriodorsally
@@ -31533,6 +31534,7 @@ hydroxytyrosine
 hydroxyvalerate
 hydroxyvitamin
 hygiene
+hygro
 hygromycin
 hygroscopic
 hygrosensitive
@@ -33810,6 +33812,7 @@ interpretive
 interpretively
 interprets
 interprocess
+interpseudotracheal
 interrelate
 interrelated
 interrelatedly
@@ -35587,6 +35590,7 @@ lateromedial
 lateromedially
 lateropharyngeal
 lateroposterior
+lateroposteriorly
 lateroscutal
 laterotergite
 lateroventral
@@ -37359,6 +37363,7 @@ mandelic
 mandelonitrile
 mandible
 mandibles
+mandibula
 mandibular
 mandibulary
 mandolin
@@ -37947,10 +37952,12 @@ medieval's
 medievally
 medievals
 medio
+medioanterior
 mediodorsal
 mediodorsally
 mediolateral
 mediolaterally
+medioposterior
 medioscutal
 mediosternal
 medioventral
@@ -37970,7 +37977,9 @@ medium
 medium's
 mediums
 medulla
+medullar
 medullary
+medullo
 meek
 meeker
 meekest
@@ -40694,6 +40703,7 @@ nerve
 nerve's
 nerved
 nerves
+nervi
 nerving
 nervous
 nervously
@@ -43330,6 +43340,7 @@ paperwork
 papilla
 papillae
 papillar
+papillum
 paprika
 par
 para
@@ -43407,6 +43418,7 @@ paranoia
 paranoid
 paranuclear
 paraocciput
+paraoesophageal
 paraoxon
 paraoxonase
 parapet
@@ -59368,6 +59380,7 @@ thong
 thonged
 thoracic
 thoracico
+thoracoabdominal
 thorax
 thorn
 thorn's
@@ -61051,6 +61064,7 @@ tuber
 tubercle
 tubercles
 tubercular
+tuberculo
 tuberculosis
 tuberin
 tuberous
@@ -63420,6 +63434,7 @@ ventilations
 ventilative
 venting
 ventral
+ventrales
 ventrally
 ventralmost
 ventricle
@@ -63437,6 +63452,7 @@ ventrolateral
 ventrolaterally
 ventromedial
 ventromedially
+ventromedian
 ventroposterior
 ventroposteriorly
 vents


### PR DESCRIPTION
This PR adds a script to perform spellchecking on the generated `fbbt-simple.obo` file and generate a report in `reports/spellcheck.txt`.

The report will be generated at the same time as the other reports when running the release process. It can also be generated on-demand, outside of any release, by running:

```sh
$ sh run.sh make IMP=false reports/spellcheck.txt
```