### PR TITLE
New terms for various types of epithelial cells

### DIFF
--- a/src/ontology/components/flybase_import.owl
+++ b/src/ontology/components/flybase_import.owl
@@ -2494,6 +2494,28 @@
     
 
 
+    <!-- http://flybase.org/reports/FBgn0027343 -->
+
+    <owl:Class rdf:about="http://flybase.org/reports/FBgn0027343">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG16785</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DFz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dfrizzled-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dfz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm Fz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EG:34F3.6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Frizzled 3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dFrizzled3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dFz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dfz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frizzled 3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frizzled3</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fz3</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://flybase.org/reports/FBgn0027945 -->
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0027945">


### PR DESCRIPTION
This PR is part of #1223 and adds terms referring to epithelial cells in various locations in the reproductive organs (male ejaculatory ducts/bulb, female oviduct) and the gastro-intestinal tract. It also adds `midgut muscle` and `foregut muscle` (on par with the already existing `hindgut muscle`) and `pericerebral fat cell`.