### PR TITLE
Misc new terms for the Fly Cell Atlas

### DIFF
--- a/src/ontology/components/flybase_import.owl
+++ b/src/ontology/components/flybase_import.owl
@@ -3829,6 +3829,19 @@
     
 
 
+    <!-- http://flybase.org/reports/FBgn0037672 -->
+
+    <owl:Class rdf:about="http://flybase.org/reports/FBgn0037672">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12952</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sage</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bHLHc7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">salivary gland-expressed bHLH</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sage</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://flybase.org/reports/FBgn0037685 -->
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037685">


### PR DESCRIPTION
This is the last batch of terms to be added for the FCA (#1223):

* `adult salivary gland secretory cell` for the cells of the `salivary gland proper` that actually secrete the saliva (opposed to the salivary gland duct cells);
* `semen-secreting cell of the male reproductive system` to encompass all cells contributing to the production of the seminal fluid (mostly the cells of the male accessory gland but also some less-characterised cells in the seminal vesicles and the ejaculatory bulb).