### PR TITLE
Fix generation of mappings.sssom.tsv.

### DIFF
--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -185,7 +185,7 @@ components/flybase_import.owl: tmp/FBgn_template.tsv
 #######################################################################
 
 mappings.sssom.tsv: mappings.tsv ../scripts/mappings2sssom.awk
-	sort -t'\t' -k1,4 $< | awk -f ../scripts/mappings2sssom.awk > $@
+	sort -t'	' -k1,4 $< | awk -f ../scripts/mappings2sssom.awk > $@
 
 tmp/exact_mapping_template.tsv: mappings.sssom.tsv
 	echo 'ID	Cross-reference' > $@


### PR DESCRIPTION
The call to the sort command using the `\t` syntax is not portable and does not work on the Ubuntu running inside the ODK container (though it works on native Mac OS).

Replace the `\t` with an actual tab character. This makes the rule a little bit less clear (it is not obvious than we are using a tab character as field separator), but at least it works everywhere. And the source file extension (tsv) should make it clear enough that we are dealing with tab-separated values.