### PR TITLE
Disallow inferred equivalencies when reasoning.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -66,7 +66,7 @@ all: odkversion all_imports patterns all_main all_subsets sparql_test all_report
 
 .PHONY: test
 test: odkversion sparql_test all_reports 
-	$(ROBOT) reason --input $(SRC) --reasoner ELK  --equivalent-classes-allowed asserted-only --exclude-tautologies structural --output test.owl && rm test.owl && echo "Success"
+	$(ROBOT) reason --input $(SRC) --reasoner ELK  --equivalent-classes-allowed none --exclude-tautologies structural --output test.owl && rm test.owl && echo "Success"
 
 .PHONY: odkversion
 odkversion:
@@ -516,7 +516,7 @@ $(ONT)-base.owl: $(SRC) $(OTHER_SRC)
 # Full: The full artefacts with imports merged, reasoned
 $(ONT)-full.owl: $(SRC) $(OTHER_SRC)
 	$(ROBOT) merge --input $< \
-		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
+		reason --reasoner ELK --equivalent-classes-allowed none --exclude-tautologies structural \
 		relax \
 		reduce -r ELK \
 		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) --annotation oboInOwl:date "$(OBODATE)" --output $@.tmp.owl && mv $@.tmp.owl $@
@@ -531,7 +531,7 @@ $(ONT)-non-classified.owl: $(SRC) $(OTHER_SRC)
 
 $(ONT)-simple.owl: $(SRC) $(OTHER_SRC) $(SIMPLESEED)
 	$(ROBOT) merge --input $< $(patsubst %, -i %, $(OTHER_SRC)) \
-		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
+		reason --reasoner ELK --equivalent-classes-allowed none --exclude-tautologies structural \
 		relax \
 		remove --axioms equivalent \
 		relax \

--- a/src/ontology/fbbt-odk.yaml
+++ b/src/ontology/fbbt-odk.yaml
@@ -26,5 +26,5 @@ import_group:
       module_type: minimal
 edit_format: obo
 robot_java_args: '-Xmx8G'
-allow_equivalents: asserted-only
+allow_equivalents: none
 release_date: TRUE

--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -241,7 +241,7 @@ flybase_qc.owl: odkversion obo_qc
 	$(ROBOT) merge -i $(ONT)-full.owl -i components/qc_assertions.owl -o $@
 
 flybase_qc: flybase_qc.owl
-	$(ROBOT) reason --input $< --reasoner ELK  --equivalent-classes-allowed asserted-only --output test.owl &&\
+	$(ROBOT) reason --input $< --reasoner ELK  --equivalent-classes-allowed none --output test.owl &&\
 	rm test.owl &&\
 	echo "Success"
 


### PR DESCRIPTION
Make ROBOT fail when the reasoner finds inferred equivalent classes.

As recommended by Chris Mungall ([rationale](https://douroucouli.wordpress.com/2018/09/04/debugging-ontologies-using-owl-reasoning-part-2-unintentional-entailed-equivalence/)) and NicoMatentzoglu on Slack.