### PR TITLE
Add a subset for cell types selected for scRNAseq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ src/ontology/fbbt-test.owl
 *.pyc
 
 src/ontology/mappings.sssom.tsv
+
+src/ontology/*-slim.owl

--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -221,6 +221,15 @@ post_release: obo_qc fly_anatomy.obo reports/chado_load_check_simple.txt
 	cp fly_anatomy.obo ../..
 	mv obo_qc_$(ONT).obo.txt reports/obo_qc_$(ONT).obo.txt
 	mv obo_qc_$(ONT).owl.txt reports/obo_qc_$(ONT).owl.txt
+
+
+#######################################################################
+### Subsets
+#######################################################################
+
+scrnaseq-slim.owl: $(ONT)-simple.owl
+	owltools --use-catalog $< --extract-ontology-subset --subset scrnaseq_slim \
+		--iri $(URIBASE)/fbbt/scrnaseq-slim.owl -o $@
 	
 	
 ########################


### PR DESCRIPTION
Create a new subset tag `scrnaseq_slim` and mark a selection of “major” cell types with it. These will be the cell types displayed in a future ribbon dedicated to scRNAseq data.