### PR TITLE
Update FBbt-CL mappings

### DIFF
--- a/src/ontology/components/exact_mappings.owl
+++ b/src/ontology/components/exact_mappings.owl
@@ -2435,14 +2435,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/FBbt_00005127 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005127">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000561</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/FBbt_00005128 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005128">
@@ -2518,7 +2510,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005146 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005146">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000031</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000338</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2631,7 +2623,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005219">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000382</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000409</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2640,14 +2631,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005221">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000407</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00005222 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005222">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:00003828</oboInOwl:hasDbXref>
     </owl:Class>
     
 

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -34,7 +34,7 @@ FBbt:00057012	CL:0000025	exact	female germline cell
 FBbt:00005130	CL:0000381	exact	neurosecretory neuron
 FBbt:00005171	CL:0000372	exact	tormogen cell
 FBbt:00005038	CL:0000307	exact	tracheocyte
-FBbt:00005146	CL:0000031	exact	neuroblast
+FBbt:00005146	CL:0000338	exact	neuroblast
 FBbt:00005062	CL:0000385	exact	prohemocyte
 FBbt:00004873	CL:0000022	exact	female germline stem cell
 FBbt:00005148	CL:0000405	exact	neuroepidermoblast

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -6,8 +6,7 @@ FBbt:00005125	CL:0000099	exact	interneuron
 FBbt:00005917	CL:0000735	exact	lymph gland derived hemocyte
 FBbt:00005059	CL:0000486	exact	garland cell
 FBbt:00005128	CL:0000116	exact	pioneer neuron
-FBbt:00005219	CL:0000382	exact	scolopale cell	CL:0000409 seems redundant with CL:0000382
-FBbt:00005219	CL:0000409	exact	scolopale cell	CL:0000409 seems redundant with CL:0000382
+FBbt:00005219	CL:0000382	exact	scolopale cell
 FBbt:00007002	CL:0000000	exact	cell
 FBbt:00001690	CL:0000715	exact	embryonic/larval crystal cell
 FBbt:00004942	CL:0000018	exact	spermatid

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -458,5 +458,4 @@ FBbt:00000092	CL:0000301	exact	primordial germ cell
 FBbt:00005063	CL:0000387	exact	hemocyte
 FBbt:00003219	CL:0000462	exact	adepithelial cell
 FBbt:00001666	CL:0000465	exact	cardioblast
-FBbt:00005127	CL:0000561	exact	amacrine neuron	CL term is vertebrate-specific
 FBbt:00005797	CL:1000155	exact	Malpighian tubule Type II cell

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -45,7 +45,7 @@ FBbt:00004211	CL:2000019	exact	photoreceptor cell
 FBbt:00001689	CL:0000395	exact	procrystal cell
 FBbt:00004994	CL:0000464	exact	epidermoblast
 FBbt:00001789	CL:0000373	exact	histoblast
-FBbt:00004954	CL:0000019	exact	spermatozoon	In CL 'spermatozoon' is an EXACT synonym for sperm, whereas in FBbt it is RELATED
+FBbt:00004954	CL:0000019	exact	spermatozoon
 FBbt:00004878	CL:0000026	exact	nurse cell
 FBbt:00004995	CL:0000487	exact	oenocyte
 FBbt:00005133	CL:0000403	exact	serotonergic neuron

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -52,7 +52,6 @@ FBbt:00005133	CL:0000403	exact	serotonergic neuron
 FBbt:00005221	CL:0000407	exact	scolopidial ligament cell
 FBbt:00005123	CL:0000100	exact	motor neuron
 FBbt:00005083	CL:0000056	exact	myoblast
-FBbt:00005222	CL:00003828	exact	chordotonal neuron	FIXME: bogus CL ID
 FBbt:00005124	CL:0000101	exact	sensory neuron
 FBbt:00005812	CL:0002372	exact	myotube
 FBbt:00004941	CL:0000657	exact	secondary spermatocyte


### PR DESCRIPTION
Fix all mappings with CL that were marked as problematic for one reason or another:

- Map `neuroblast` to the invertebrate-specific term;
- Remove mapping between FBbt’s `scolopale cell` and CL’s `scolopidial sheath cell` (the CL term is redundant with another CL term already mapped to FBbt’s `scolopale cell`);
- Remove mapping between FBbt’s `chordotonal neuron` and a non-existent CL term;
- Remove mapping between FBbt’s `amacrine neuron` and CL’s `amacrine cell` (the CL term is vertebrate-specific).

As an aside, this PR also makes `sperm` an exact synonym for `spermatozoon` (instead of a related synonym). This is to align with CL, and also with literature usage.