### PR TITLE
Update uberon mappings

### DIFF
--- a/src/ontology/components/exact_mappings.owl
+++ b/src/ontology/components/exact_mappings.owl
@@ -563,7 +563,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001057 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001057">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001057</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002346</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -580,22 +580,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001060">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001060</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00001061 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001061">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002346</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00001102 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001102">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000934</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1305,6 +1289,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00003039 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003039">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003039</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00003125 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003125">
@@ -1321,26 +1313,9 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/FBbt_00003148 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003148">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001245</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00003152 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003152">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0015231</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/FBbt_00003154 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003154">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0007100</oboInOwl:hasDbXref>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0015230</oboInOwl:hasDbXref>
     </owl:Class>
     
@@ -1366,14 +1341,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003259">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003259</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00003525 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003525">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001135</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1850,14 +1817,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/FBbt_00004859 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004859">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0004909</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/FBbt_00004861 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004861">
@@ -1910,14 +1869,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004894">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003199</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00004896 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004896">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0004911</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2046,14 +1997,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004954">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000019</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00004955 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004955">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0004910</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2197,7 +2140,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005043 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005043">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003127</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005043</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2229,7 +2172,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005057 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005057">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001009</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0009054</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2306,11 +2249,18 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00005070 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005070">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0008007</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00005073 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005073">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0005090</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0014895</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0008004</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2363,6 +2313,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00005097 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005097">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000934</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00005098 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005098">
@@ -2383,14 +2341,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005100">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001018</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00005103 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005103">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001020</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2467,26 +2417,10 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/FBbt_00005137 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005137">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000045</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/FBbt_00005139 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005139">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002606</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00005140 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005140">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0004732</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3326,7 +3260,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007276 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007276">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000480</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0034923</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3539,6 +3473,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00047153 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00047153">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001245</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00057001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00057001">
@@ -3551,6 +3493,14 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00057012">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000025</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FBbt_00058291 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00058291">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0015231</oboInOwl:hasDbXref>
     </owl:Class>
     
 

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -206,7 +206,6 @@ FBbt:00007018	UBERON:0010758	exact	appendage segment
 FBbt:00007330	UBERON:0011216	exact	organ system subdivision
 FBbt:00001718	UBERON:0012325	exact	retrocerebral complex	Uberon term commented as “will be ceded to arthropod anatomy ontology”
 FBbt:00007230	UBERON:0014732	exact	compound cell cluster organ
-FBbt:00005073	UBERON:0014895	exact	somatic muscle	It seems strange that the Uberon term is invertebrate-specific; I assume the corresponding vertebrate term is 'skeletal muscle tissue', but I believe 'somatic' is also widely used in vertebrates"
 FBbt:00007278	UBERON:0015203	exact	non-connected functional system
 FBbt:00003154	UBERON:0015230	exact	adult heart	FBbt’s adult heart is already mapped to ‘primary circulatory organ’
 FBbt:00003152	UBERON:0015231	exact	adult dorsal vessel

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -192,7 +192,6 @@ FBbt:00004924	UBERON:0006834	exact	uterus	Debatable: The fly uterus is the site 
 FBbt:00005756	UBERON:0006866	exact	rectum
 FBbt:00004958	UBERON:0006868	exact	seminal vesicle
 FBbt:00003004	UBERON:0007023	exact	adult
-FBbt:00003154	UBERON:0007100	exact	adult heart
 FBbt:00004993	UBERON:0007376	exact	epidermis
 FBbt:00005426	UBERON:0007688	exact	anlage
 FBbt:00004850	UBERON:0008811	exact	phallus
@@ -207,8 +206,8 @@ FBbt:00007330	UBERON:0011216	exact	organ system subdivision
 FBbt:00001718	UBERON:0012325	exact	retrocerebral complex	Uberon term commented as “will be ceded to arthropod anatomy ontology”
 FBbt:00007230	UBERON:0014732	exact	compound cell cluster organ
 FBbt:00007278	UBERON:0015203	exact	non-connected functional system
-FBbt:00003154	UBERON:0015230	exact	adult heart	FBbt’s adult heart is already mapped to ‘primary circulatory organ’
-FBbt:00003152	UBERON:0015231	exact	adult dorsal vessel
+FBbt:00003154	UBERON:0015230	exact	adult heart	FBbt is missing a stage-neutral ‘heart’
+FBbt:00058291	UBERON:0015231	exact	dorsal vessel
 FBbt:00005338	UBERON:0018382	exact	second instar larva	marked as deprecated in FBbt (but without suggested replacement)
 FBbt:00004987	UBERON:0018656	exact	puparium cuticle
 FBbt:00100152	UBERON:0034926	exact	row

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -63,7 +63,6 @@ FBbt:00004508	UBERON:0000018	exact	eye
 FBbt:00005155	UBERON:0000020	exact	sense organ
 FBbt:00007000	UBERON:0000026	exact	appendage
 FBbt:00000004	UBERON:0000033	exact	head
-FBbt:00005137	UBERON:0000045	exact	ganglion
 FBbt:00100314	UBERON:0000058	exact	duct
 FBbt:00007001	UBERON:0000061	exact	anatomical structure
 FBbt:00004927	UBERON:0000079	exact	male reproductive system

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -88,7 +88,7 @@ FBbt:00007003	UBERON:0000479	exact	portion of tissue
 FBbt:00007276	UBERON:0034923	exact	anatomical group
 FBbt:00007010	UBERON:0000481	exact	multi-tissue structure
 FBbt:00007005	UBERON:0000483	exact	epithelium
-FBbt:00007027	UBERON:0000485	exact	cuboidal/columnar epithelium	FBbt definition does not include the “unilaminar” bit
+FBbt:00007027	UBERON:0000485	exact	cuboidal/columnar epithelium
 FBbt:00000003	UBERON:0000914	exact	segment
 FBbt:00000038	UBERON:0000920	exact	chorion
 FBbt:00000052	UBERON:0000922	exact	embryo

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -173,7 +173,7 @@ FBbt:00007474	UBERON:0003914	exact	epithelial tube
 FBbt:00005066	UBERON:0003917	exact	fat body	Uberon definition makes it a single gland localized dorsally to the gut; FBbt definition makes it distributed throughout the body; and not sure it's correct to define it as a gland
 FBbt:00025998	UBERON:0004120	exact	mesodermal derivative
 FBbt:00025990	UBERON:0004121	exact	ectodermal derivative
-FBbt:00005140	UBERON:0004732	exact	neuromere	Should point to neuromere (Uberon:0004731)?
+FBbt:00005140	UBERON:0004731	exact	neuromere
 FBbt:00005317	UBERON:0004734	exact	gastrula embryo	marked as deprecated in FBbt (but without suggested replacement)
 FBbt:00001956	UBERON:0004904	exact	optic nerve	To check
 FBbt:00005811	UBERON:0004905	exact	articulation

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -121,7 +121,6 @@ FBbt:00005061	UBERON:0001011	exact	hemolymph
 FBbt:00005093	UBERON:0001016	exact	nervous system
 FBbt:00005094	UBERON:0001017	exact	central nervous system
 FBbt:00005100	UBERON:0001018	exact	tract
-FBbt:00005103	UBERON:0001020	exact	symmetrical commissure	See Uberon ticket #325
 FBbt:00005105	UBERON:0001021	exact	nerve
 FBbt:00005136	UBERON:0001027	exact	sensory nerve
 FBbt:00007692	UBERON:0001032	exact	sensory system

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -154,7 +154,8 @@ FBbt:00005139	UBERON:0002606	exact	neuropil
 FBbt:00007011	UBERON:0003100	exact	female organism
 FBbt:00007004	UBERON:0003101	exact	male organism
 FBbt:00000042	UBERON:0003125	exact	vitelline membrane
-FBbt:00005043	UBERON:0003127	exact	trachea
+FBbt:00005043	UBERON:6005043	exact	trachea
+FBbt:00003039	UBERON:6003039	exact	adult dorsal trunk
 FBbt:00004557	UBERON:0003130	exact	sternum
 FBbt:00004642	UBERON:0003131	exact	tibia
 FBbt:00002952	UBERON:0003142	exact	prepupa

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -165,7 +165,7 @@ FBbt:00004505	UBERON:0003161	exact	ocellus
 FBbt:00004506	UBERON:0003162	exact	lateral ocellus
 FBbt:00004751	UBERON:0003194	exact	wing vein
 FBbt:00004894	UBERON:0003199	exact	egg chamber	Uberon term commented as “candidate for obsoletion”
-FBbt:00004973	UBERON:0003201	exact	exocuticle	FBbt’s definition makes it pupa-specific
+FBbt:00004973	UBERON:0003201	exact	exocuticle
 FBbt:00004974	UBERON:0003202	exact	endocuticle	Conflicting definition (inner layer in Uberon; middle layer in FBbt)
 FBbt:00004507	UBERON:0003211	exact	medial ocellus	Uberon term should be under ‘dorsal ocellus’ (CL:0003161)
 FBbt:00005159	UBERON:0003212	exact	gustatory sensory organ

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -116,7 +116,7 @@ FBbt:00004921	UBERON:0000994	exact	spermathecum
 FBbt:00004970	UBERON:0001001	exact	cuticle
 FBbt:00005055	UBERON:0001007	exact	digestive system
 FBbt:00005056	UBERON:0001008	exact	excretory system
-FBbt:00005057	UBERON:0001009	exact	circulatory system	Should point to ‘open circulatory system’ (UBERON:0009054)?
+FBbt:00005057	UBERON:0009054	exact	circulatory system
 FBbt:00005061	UBERON:0001011	exact	hemolymph
 FBbt:00005093	UBERON:0001016	exact	nervous system
 FBbt:00005094	UBERON:0001017	exact	central nervous system

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -178,8 +178,6 @@ FBbt:00005317	UBERON:0004734	exact	gastrula embryo	marked as deprecated in FBbt 
 FBbt:00001956	UBERON:0004904	exact	optic nerve	To check
 FBbt:00005811	UBERON:0004905	exact	articulation
 FBbt:00047208	UBERON:0004909	exact	gonadal sheath epithelium
-FBbt:00004955	UBERON:0004910	exact	testis sheath	The FBbt term does not refer to an epithelium (the testis sheath contains an epithelial layer but also a muscular layer); maybe FBbt should have a 'male gonadal sheath epithelium'?
-FBbt:00004896	UBERON:0004911	exact	ovarian sheath	Likewise
 FBbt:00100315	UBERON:0004921	exact	gut section
 FBbt:00005024	UBERON:0005155	exact	tracheal system
 FBbt:00007060	UBERON:0005162	exact	multi-cell-component structure

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -178,7 +178,7 @@ FBbt:00005140	UBERON:0004732	exact	neuromere	Should point to neuromere (Uberon:0
 FBbt:00005317	UBERON:0004734	exact	gastrula embryo	marked as deprecated in FBbt (but without suggested replacement)
 FBbt:00001956	UBERON:0004904	exact	optic nerve	To check
 FBbt:00005811	UBERON:0004905	exact	articulation
-FBbt:00004859	UBERON:0004909	exact	gonadal sheath	Source term should be ‘gonadal sheath epithelium’ (FBbt:00047208)
+FBbt:00047208	UBERON:0004909	exact	gonadal sheath epithelium
 FBbt:00004955	UBERON:0004910	exact	testis sheath	The FBbt term does not refer to an epithelium (the testis sheath contains an epithelial layer but also a muscular layer); maybe FBbt should have a 'male gonadal sheath epithelium'?
 FBbt:00004896	UBERON:0004911	exact	ovarian sheath	Likewise
 FBbt:00100315	UBERON:0004921	exact	gut section

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -99,7 +99,7 @@ FBbt:00000126	UBERON:0000926	exact	mesoderm
 FBbt:00000136	UBERON:0000927	exact	mesectoderm
 FBbt:00000439	UBERON:0000930	exact	stomodeum
 FBbt:00000123	UBERON:0000931	exact	amnioproctodeal invagination
-FBbt:00001102	UBERON:0000934	exact	larval ventral nerve cord	Source term should be ‘ventral nerve cord’ (FBbt:00005097)?
+FBbt:00005097	UBERON:0000934	exact	ventral nerve cord
 FBbt:00001761	UBERON:0000939	exact	imaginal disc
 FBbt:00005068	UBERON:0000949	exact	endocrine system
 FBbt:00005095	UBERON:0000955	exact	brain

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -145,7 +145,7 @@ FBbt:00003125	UBERON:0001555	exact	alimentary canal
 FBbt:00004208	UBERON:0002050	exact	developing embryonic structure
 FBbt:00005158	UBERON:0002268	exact	olfactory sensory organ
 FBbt:00005060	UBERON:0002323	exact	hemocoel
-FBbt:00001061	UBERON:0002346	exact	ventral neurectoderm	Source term should be ‘neurogenic region’ (FBbt:00001057)
+FBbt:00001057	UBERON:0002346	exact	neurogenic region
 FBbt:00004969	UBERON:0002416	exact	integumentary system
 FBbt:00100317	UBERON:0002530	exact	gland
 FBbt:00007152	UBERON:0002536	exact	sensillum
@@ -263,7 +263,6 @@ FBbt:00000181	UBERON:6000181	exact	embryonic abdominal segment 9
 FBbt:00000186	UBERON:6000186	exact	embryonic optic lobe primordium
 FBbt:00001055	UBERON:6001055	exact	presumptive embryonic/larval nervous system
 FBbt:00001056	UBERON:6001056	exact	presumptive embryonic/larval central nervous system
-FBbt:00001057	UBERON:6001057	exact	neurogenic region
 FBbt:00001059	UBERON:6001059	exact	visual primordium
 FBbt:00001060	UBERON:6001060	exact	embryonic brain
 FBbt:00001135	UBERON:6001135	exact	proneural cluster

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -86,7 +86,7 @@ FBbt:00007013	UBERON:0000476	exact	acellular anatomical structure
 FBbt:00007277	UBERON:0000477	exact	anatomical cluster
 FBbt:00005835	UBERON:0000478	exact	extraembryonic structure
 FBbt:00007003	UBERON:0000479	exact	portion of tissue
-FBbt:00007276	UBERON:0000480	exact	anatomical group	Uberon term has problematic definition (ticket #1430)
+FBbt:00007276	UBERON:0034923	exact	anatomical group
 FBbt:00007010	UBERON:0000481	exact	multi-tissue structure
 FBbt:00007005	UBERON:0000483	exact	epithelium
 FBbt:00007027	UBERON:0000485	exact	cuboidal/columnar epithelium	FBbt definition does not include the “unilaminar” bit

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -139,7 +139,7 @@ FBbt:00005801	UBERON:0001058	exact	mushroom body
 FBbt:00005802	UBERON:0001059	exact	pars intercerebralis
 FBbt:10000000	UBERON:0001062	exact	anatomical entity
 FBbt:00003525	UBERON:0001135	exact	adult visceral muscle	Source term should be ‘visceral muscle’ (FBbt:00005070)
-FBbt:00003148	UBERON:0001245	exact	adult anus	Source term should be ‘anus’ (FBbt:00047153)
+FBbt:00047153	UBERON:0001245	exact	anus
 FBbt:00003125	UBERON:0001555	exact	alimentary canal
 FBbt:00004208	UBERON:0002050	exact	developing embryonic structure
 FBbt:00005158	UBERON:0002268	exact	olfactory sensory organ

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -173,11 +173,9 @@ FBbt:00007474	UBERON:0003914	exact	epithelial tube
 FBbt:00005066	UBERON:0003917	exact	fat body	Uberon definition makes it a single gland localized dorsally to the gut; FBbt definition makes it distributed throughout the body; and not sure it's correct to define it as a gland
 FBbt:00025998	UBERON:0004120	exact	mesodermal derivative
 FBbt:00025990	UBERON:0004121	exact	ectodermal derivative
-FBbt:00005140	UBERON:0004731	exact	neuromere
 FBbt:00005317	UBERON:0004734	exact	gastrula embryo	marked as deprecated in FBbt (but without suggested replacement)
 FBbt:00001956	UBERON:0004904	exact	optic nerve	To check
 FBbt:00005811	UBERON:0004905	exact	articulation
-FBbt:00047208	UBERON:0004909	exact	gonadal sheath epithelium
 FBbt:00100315	UBERON:0004921	exact	gut section
 FBbt:00005024	UBERON:0005155	exact	tracheal system
 FBbt:00007060	UBERON:0005162	exact	multi-cell-component structure

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -55,6 +55,8 @@ FBbt:00005083	CL:0000056	exact	myoblast
 FBbt:00005124	CL:0000101	exact	sensory neuron
 FBbt:00005812	CL:0002372	exact	myotube
 FBbt:00004941	CL:0000657	exact	secondary spermatocyte
+FBbt:00005070	CL:0008007	exact	visceral muscle cell
+FBbt:00005073	CL:0008004	exact	somatic muscle cell
 
 # Imported mappings from UBERON's xrefs
 FBbt:00005157	UBERON:0000005	exact	chemosensory sensory organ
@@ -138,7 +140,6 @@ FBbt:00005800	UBERON:0001057	exact	corpus allatum
 FBbt:00005801	UBERON:0001058	exact	mushroom body
 FBbt:00005802	UBERON:0001059	exact	pars intercerebralis
 FBbt:10000000	UBERON:0001062	exact	anatomical entity
-FBbt:00003525	UBERON:0001135	exact	adult visceral muscle	Source term should be ‘visceral muscle’ (FBbt:00005070)
 FBbt:00047153	UBERON:0001245	exact	anus
 FBbt:00003125	UBERON:0001555	exact	alimentary canal
 FBbt:00004208	UBERON:0002050	exact	developing embryonic structure
@@ -180,7 +181,6 @@ FBbt:00047208	UBERON:0004909	exact	gonadal sheath epithelium
 FBbt:00004955	UBERON:0004910	exact	testis sheath	The FBbt term does not refer to an epithelium (the testis sheath contains an epithelial layer but also a muscular layer); maybe FBbt should have a 'male gonadal sheath epithelium'?
 FBbt:00004896	UBERON:0004911	exact	ovarian sheath	Likewise
 FBbt:00100315	UBERON:0004921	exact	gut section
-FBbt:00005073	UBERON:0005090	exact	somatic muscle	No real correspondance in FBbt (we only have muscle cells and no term for actual muscles; see FBbt ticket #1128)
 FBbt:00005024	UBERON:0005155	exact	tracheal system
 FBbt:00007060	UBERON:0005162	exact	multi-cell-component structure
 FBbt:00004200	UBERON:0005388	exact	retina


### PR DESCRIPTION
This PR fixes some of the problems with the current mappings between FBbt and Uberon, notably some highlighted in #201.

It focuses on issues that can be addressed solely by editing the mappings themselves, without requiring any changes to FBbt or Uberon terms (including addition of new terms).

The following changes have been discussed in #201:

* Remap FBbt‘s `anatomical group` to Uberon’s `disconnected anatomical group` (instead of `anatomical group`, which has a definition that makes it incompatible with the FBbt term despite the identical label).
* Remap Uberon’s `epithelium of gonad` to FBbt’s recently added `gonadal sheath epithelium`( instead of `gonadal sheath`, which refers to a structure containing a muscular layer in addition to an epithelium).
* Remove the mapping between FBbt’s `ganglion` and Uberon’s `ganglion`, which have incompatible classifications (`multi-tissue structure` in FBbt, `cell cluster organ` in Uberon).

Other changes include:

* Whenever possible, stage-specific terms on the FBbt end of the mappings are replaced by stage-neutral terms (e.g., map Uberon’s `ventral nerve cord` to FBbt’s `ventral nerve cord` instead of `larval ventral nerve cord`, or Uberon’s `circulatory system dorsal vessel` to FBbt’s `dorsal vessel` instead of `adult dorsal vessel`).
* Remap FBbt’s `circulatory system` to Uberon’s `open circulatory system` (instead of the more general `circulatory system`).
* Remove the mapping between FBbt’s `symmetrical commissure` and Uberon’s `nervous system commissure` (problematic due to the Uberon term being linked to the concept of white matter; removal of the mapping suggested by Chris Mungall in the discussion about obophenotype/uberon#325).
* Remap FBbt terms for muscle _cells_ to the appropriate terms in CL rather than to the Uberon terms that are referring to the muscles themselves.
* Remap Uberon’s `neurectoderm` to FBbt’s `neurogenic region` (instead of the more specific `ventral neurectoderm`).
* Remap FBbt‘s `neuromere` to Uberon’s `neuromere` (instead of `segmental division of nervous system`, to which it was previously mapped – most likely as a result of a typo, the two Uberon terms having consecutive IDs).
* Remove the mapping between FBbt’s `testis sheath` and Uberon’s `epithelium of male gonad` (the FBbt term refers to a structure containing a muscular layer; we currently do not have a term to refer solely to the epithelium of the male gonad, so better to remove the mapping for now). Likewise for for the mapping between FBbt’s `ovarian sheath` and `epithelium of female gonad`.
* Remove superfluous mapping between FBbt’s `adult heart` and Uberon’s `primary circulatory organ` (the FBbt term is already mapped to Uberon’s `dorsal vessel heart`, which is a subclass of `primary circulatory organ`).