### PR TITLE
Add checks for missing ID and missing/invalid namespace.

### DIFF
--- a/src/ontology/qc-profile.txt
+++ b/src/ontology/qc-profile.txt
@@ -23,3 +23,5 @@ ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
 ERROR	file:../sparql/duplicate_symbol.sparql
 ERROR	file:../sparql/duplicate_label_fbbt.sparql
+ERROR	file:../sparql/missing-id-or-namespace.sparql
+ERROR	file:../sparql/invalid-namespace.sparql

--- a/src/sparql/invalid-namespace.sparql
+++ b/src/sparql/invalid-namespace.sparql
@@ -1,0 +1,18 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT ?cls ?namespace WHERE {
+  # Select classes with an invalid namespace
+  ?cls a owl:Class ;
+       oio:hasOBONamespace ?namespace .
+  FILTER ( ?namespace != "fly_anatomy.ontology" )
+
+  # Exclude blank nodes and obsoleted terms
+  FILTER ( ! isBlank(?cls) )
+  FILTER NOT EXISTS { ?cls owl:deprecated true }
+
+  # Exclude everything not coming from FBbt
+  # (this notably includes imported FBgn pseudo-terms)
+  FILTER regex(str(?cls), "^http://purl.obolibrary.org/obo/FBbt_")
+}
+ORDER BY ?cls

--- a/src/sparql/missing-id-or-namespace.sparql
+++ b/src/sparql/missing-id-or-namespace.sparql
@@ -1,0 +1,19 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT ?cls ?property WHERE {
+  VALUES ?property { oio:id oio:hasOBONamespace }
+
+  # Select classes missing (at least) one of the properties
+  ?cls a owl:Class .
+  FILTER NOT EXISTS { ?cls ?property ?value }
+
+  # Exclude blank nodes and obsoleted terms
+  FILTER ( ! isBlank(?cls) )
+  FILTER NOT EXISTS { ?cls owl:deprecated true }
+
+  # Exclude everything not coming from FBbt
+  # (this notably includes imported FBgn pseudo-terms)
+  FILTER regex(str(?cls), "^http://purl.obolibrary.org/obo/FBbt_")
+}
+ORDER BY ?cls


### PR DESCRIPTION
Add two more checks to the QC profile:

- one to check for classes missing either `oboInOwl:id` or `oboInOwl:hasOBONamespace` annotations;
- one to check that the `hasOBONamespace` annotation, when present, has the expected value "fly_anatomy.ontology".

closes #1333