### PR TITLE
Remove FBbt-specific domain or range restrictions.

### DIFF
--- a/src/ontology/components/fbbt_ext.owl
+++ b/src/ontology/components/fbbt_ext.owl
@@ -106,21 +106,18 @@ Declaration(AnnotationProperty(rdfs:label))
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_creation_date> <http://purl.obolibrary.org/obo/RO_0002003> "2010-01-06T06:53:45Z")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_id> <http://purl.obolibrary.org/obo/RO_0002003> "electrically_synapsed_to")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/RO_0002003> "electrically_synapsed_to")
-ObjectPropertyDomain(<http://purl.obolibrary.org/obo/RO_0002003> <http://purl.obolibrary.org/obo/FBbt_00005106>)
 
 # Object Property: <http://purl.obolibrary.org/obo/RO_0002103> (synapsed by)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_id> <http://purl.obolibrary.org/obo/RO_0002103> "synapsed_by")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_xref> <http://purl.obolibrary.org/obo/RO_0002103> "RO:0002103")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/RO_0002103> "synapsed_by")
-ObjectPropertyRange(<http://purl.obolibrary.org/obo/RO_0002103> <http://purl.obolibrary.org/obo/FBbt_00005106>)
 
 # Object Property: <http://purl.obolibrary.org/obo/RO_0002120> (synapsed to)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_id> <http://purl.obolibrary.org/obo/RO_0002120> "synapsed_to")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_xref> <http://purl.obolibrary.org/obo/RO_0002120> "RO:0002120")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/RO_0002120> "synapsed_to")
-ObjectPropertyDomain(<http://purl.obolibrary.org/obo/RO_0002120> <http://purl.obolibrary.org/obo/FBbt_00005106>)
 
 
 


### PR DESCRIPTION
Some relations imported from RO were modified in FBbt to add a domain or a range restriction limiting them to Drosophila neurons. This is not useful and a source of issues when merging FBbt with Uberon/CL, so we remove those added restrictions.

closes #1356