### PR TITLE
Update uberon mappings

### DIFF
--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -229,7 +229,6 @@ FBbt:00000021	UBERON:6000021	exact	abdominal segment
 FBbt:00000029	UBERON:6000029	exact	abdominal segment 8	Why does Uberon only have terms for segments 8 and 9?
 FBbt:00000030	UBERON:6000030	exact	abdominal segment 9	Likewise
 FBbt:00000046	UBERON:6000046	exact	dorsal appendage
-FBbt:00000094	UBERON:6000094	exact	clypeo-labral anlage in statu nascendi
 FBbt:00000096	UBERON:6000096	exact	ventral furrow
 FBbt:00000097	UBERON:6000097	exact	cephalic furrow
 FBbt:00000104	UBERON:6000104	exact	mesoderm anlage
@@ -383,7 +382,6 @@ FBbt:00005378	UBERON:6005378	exact	wing margin
 FBbt:00005393	UBERON:6005393	exact	embryonic/larval integumentary system
 FBbt:00005396	UBERON:6005396	exact	adult integumentary system
 FBbt:00005413	UBERON:6005413	exact	anlage in statu nascendi
-FBbt:00005425	UBERON:6005425	exact	visual anlage in statu nascendi
 FBbt:00005427	UBERON:6005427	exact	ectoderm anlage
 FBbt:00005428	UBERON:6005428	exact	dorsal ectoderm anlage
 FBbt:00005434	UBERON:6005434	exact	visual anlage

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -172,8 +172,6 @@ FBbt:00004507	UBERON:0003211	exact	medial ocellus	Uberon term should be under â€
 FBbt:00005159	UBERON:0003212	exact	gustatory sensory organ
 FBbt:00007474	UBERON:0003914	exact	epithelial tube
 FBbt:00005066	UBERON:0003917	exact	fat body	Uberon definition makes it a single gland localized dorsally to the gut; FBbt definition makes it distributed throughout the body; and not sure it's correct to define it as a gland
-FBbt:00025998	UBERON:0004120	exact	mesodermal derivative
-FBbt:00025990	UBERON:0004121	exact	ectodermal derivative
 FBbt:00005317	UBERON:0004734	exact	gastrula embryo	marked as deprecated in FBbt (but without suggested replacement)
 FBbt:00001956	UBERON:0004904	exact	optic nerve	To check
 FBbt:00005811	UBERON:0004905	exact	articulation
@@ -236,8 +234,6 @@ FBbt:00000112	UBERON:6000112	exact	dorsal ectoderm
 FBbt:00000119	UBERON:6000119	exact	anterior ectoderm
 FBbt:00000128	UBERON:6000128	exact	trunk mesoderm
 FBbt:00000130	UBERON:6000130	exact	visceral mesoderm
-FBbt:00000131	UBERON:6000131	exact	mesodermal crest
-FBbt:00000132	UBERON:6000132	exact	mesodermal crest of segment T3
 FBbt:00000137	UBERON:6000137	exact	embryonic tagma
 FBbt:00000154	UBERON:6000154	exact	embryonic segment
 FBbt:00000157	UBERON:6000157	exact	embryonic head segment
@@ -393,7 +389,6 @@ FBbt:00005514	UBERON:6005514	exact	clypeo-labral disc primordium
 FBbt:00005526	UBERON:6005526	exact	dorsal epidermis primordium
 FBbt:00005533	UBERON:6005533	exact	ventral epidermis primordium
 FBbt:00005538	UBERON:6005538	exact	clypeo-labral primordium
-FBbt:00005541	UBERON:6005541	exact	cardiogenic mesoderm
 FBbt:00005558	UBERON:6005558	exact	ventral ectoderm
 FBbt:00005569	UBERON:6005569	exact	presumptive embryonic/larval tracheal system
 FBbt:00005805	UBERON:6005805	exact	Bolwig organ
@@ -427,10 +422,6 @@ FBbt:00007373	UBERON:6007373	exact	internal sense organ
 FBbt:00007424	UBERON:6007424	exact	epithelial furrow
 FBbt:00016022	UBERON:6016022	exact	abdominal histoblast primordium
 FBbt:00017021	UBERON:6017021	exact	abdominal histoblast anlage
-FBbt:00025991	UBERON:6025991	exact	anterior ectoderm derivative
-FBbt:00025993	UBERON:6025993	exact	ventral ectoderm derivative
-FBbt:00026000	UBERON:6026000	exact	trunk mesoderm derivative
-FBbt:00026002	UBERON:6026002	exact	visceral mesoderm derivative
 FBbt:00040003	UBERON:6040003	exact	non-connected developing system
 FBbt:00040005	UBERON:6040005	exact	synaptic neuropil
 FBbt:00040007	UBERON:6040007	exact	synaptic neuropil domain


### PR DESCRIPTION
Update the FBbt-to-Uberon mappings.

This PR mostly removes the mapping between FBbt’s `ectodermal derivative` and Uberon’s `ectoderm-derived structure`, since the two terms have different scopes: the Uberon term refers to any structure derived from the ectoderm throughout all developmental stages, whereas the FBbt term strictly refers to derivatives that exist during the embryonic stage only. Having those terms mapped is the ultimate cause of issue #1425.

Similarly bogus mappings between other germ layer derivatives are removed, for the same reason. Mappings with recently obsoleted terms are removed as well.

Lastly and as a side shoot, definitions are added to `germ layer derivative` and `cardiogenic mesoderm`, since they were missing.