### PR TITLE
Fix bogus mapping.

### DIFF
--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -48,7 +48,7 @@ FBbt:00001789	CL:0000373	exact	histoblast
 FBbt:00004954	CL:0000019	exact	spermatozoon
 FBbt:00004878	CL:0000026	exact	nurse cell
 FBbt:00004995	CL:0000487	exact	oenocyte
-FBbt:00005133	CL:0000403	exact	serotonergic neuron
+FBbt:00005133	CL:0000850	exact	serotonergic neuron
 FBbt:00005221	CL:0000407	exact	scolopidial ligament cell
 FBbt:00005123	CL:0000100	exact	motor neuron
 FBbt:00005083	CL:0000056	exact	myoblast


### PR DESCRIPTION
Term FBbt:0005133 (serotonergic neuron) was mapped to an inexistent CL term (CL:0000403). Update the mapping to the correct CL term (CL:0000850).