### PR TITLE
Update Uberon/CL mappings

### DIFF
--- a/src/ontology/components/exact_mappings.owl
+++ b/src/ontology/components/exact_mappings.owl
@@ -1297,14 +1297,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/FBbt_00003218 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003218">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003218</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/FBbt_00003219 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003219">
@@ -1485,14 +1477,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004481">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004481</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00004482 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004482">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003153</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2213,14 +2197,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005068">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000949</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00005069 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005069">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000383</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3277,6 +3253,14 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007289">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007289</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FBbt_00007325 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007325">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000463</oboInOwl:hasDbXref>
     </owl:Class>
     
 

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -161,7 +161,6 @@ FBbt:00004557	UBERON:0003130	exact	sternum
 FBbt:00004642	UBERON:0003131	exact	tibia
 FBbt:00002952	UBERON:0003142	exact	prepupa
 FBbt:00002953	UBERON:0003143	exact	pupa
-FBbt:00004482	UBERON:0003153	exact	head capsule	Uberon term commented as “will be ceded to arthropod anatomy ontology”
 FBbt:00004492	UBERON:0003155	exact	occiput	Uberon term commented as “belonging to another ontology but kept for disambiguation purposes”
 FBbt:00004505	UBERON:0003161	exact	ocellus
 FBbt:00004506	UBERON:0003162	exact	lateral ocellus

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -57,6 +57,7 @@ FBbt:00005812	CL:0002372	exact	myotube
 FBbt:00004941	CL:0000657	exact	secondary spermatocyte
 FBbt:00005070	CL:0008007	exact	visceral muscle cell
 FBbt:00005073	CL:0008004	exact	somatic muscle cell
+FBbt:00007325	CL:0000463	exact	epidermal cell
 
 # Imported mappings from UBERON's xrefs
 FBbt:00005157	UBERON:0000005	exact	chemosensory sensory organ

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -74,7 +74,6 @@ FBbt:00003126	UBERON:0000165	exact	adult mouth
 FBbt:00007091	UBERON:0000202	exact	subperineurial glial sheath	Debatable: the subperineurial glia does act “like” a BBB but is it enough to make the two terms equivalent?
 FBbt:00004199	UBERON:0000207	exact	lens
 FBbt:00005333	UBERON:0000323	exact	late embryo
-FBbt:00005069	UBERON:0000383	exact	muscle system
 FBbt:00007019	UBERON:0000463	exact	portion of organism substance
 FBbt:00007017	UBERON:0000464	exact	anatomical space
 FBbt:00007016	UBERON:0000465	exact	material anatomical entity
@@ -330,7 +329,6 @@ FBbt:00003020	UBERON:6003020	exact	adult prothoracic segment
 FBbt:00003021	UBERON:6003021	exact	adult mesothoracic segment
 FBbt:00003023	UBERON:6003023	exact	adult abdomen
 FBbt:00003024	UBERON:6003024	exact	adult abdominal segment
-FBbt:00003218	UBERON:6003218	exact	adult muscle system
 FBbt:00003259	UBERON:6003259	exact	adult somatic muscle
 FBbt:00003559	UBERON:6003559	exact	adult nervous system
 FBbt:00003623	UBERON:6003623	exact	adult central nervous system


### PR DESCRIPTION
Small update to the mappings between FBbt and Uberon/CL:

* Add a mapping to CL’s `epidermal cell`;
* Remove the mapping to `head capsule` (the Uberon term is mis-classified, and is one of the causes for unsats when merging Uberon and FBbt #1530);
* Remove the mapping between `muscle system` and Uberon’s `musculature of body` (the mapping is wrong given the current definition of the Uberon term, and is another cause of unsats).

The last two items are the FBbt-side fix for #1530.