### PR TITLE
Update CL mappings

### DIFF
--- a/src/ontology/components/exact_mappings.owl
+++ b/src/ontology/components/exact_mappings.owl
@@ -1369,6 +1369,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00004101 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004101">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000110</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00004114 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004114">
@@ -2353,6 +2361,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00005131 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005131">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000700</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00005133 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005133">
@@ -3121,6 +3137,22 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00007173 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007173">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000108</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FBbt_00007228 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007228">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000617</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00007229 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007229">
@@ -3281,6 +3313,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00007367 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007367">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0011110</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00007373 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007373">
@@ -3377,6 +3417,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00048032 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00048032">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:1001509</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00057001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00057001">
@@ -3413,6 +3461,14 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00100153">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6100153</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FBbt_00100291 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00100291">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000679</oboInOwl:hasDbXref>
     </owl:Class>
     
 

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -58,6 +58,13 @@ FBbt:00004941	CL:0000657	exact	secondary spermatocyte
 FBbt:00005070	CL:0008007	exact	visceral muscle cell
 FBbt:00005073	CL:0008004	exact	somatic muscle cell
 FBbt:00007325	CL:0000463	exact	epidermal cell
+FBbt:00005131	CL:0000700	exact	dopaminergic neuron
+FBbt:00007173	CL:0000108	exact	cholinergic neuron
+FBbt:00007228	CL:0000617	exact	GABAergic neuron
+FBbt:00100291	CL:0000679	exact	glutamatergic neuron
+FBbt:00048032	CL:1001509	exact	glycinergic neuron
+FBbt:00007367	CL:0011110	exact	histaminergic neuron
+FBbt:00004101	CL:0000110	exact	peptidergic neuron
 
 # Imported mappings from UBERON's xrefs
 FBbt:00005157	UBERON:0000005	exact	chemosensory sensory organ


### PR DESCRIPTION
This PR adds mappings between FBbt's _dopaminergic neuron_ (FBbt:00005131) and the equivalent class in CL (CL:0000700). Likewise for other similar types of neurons (glutamatergic neuron, GABAergic neuron, etc.).