### PR TITLE
Update SSSOM generation

### DIFF
--- a/fbbt-mappings.sssom.tsv
+++ b/fbbt-mappings.sssom.tsv
@@ -2,439 +2,445 @@
 #  FBbt: "http://purl.obolibrary.org/obo/FBbt_"
 #  UBERON: "http://purl.obolibrary.org/obo/UBERON_"
 #  CL: "http://purl.obolibrary.org/obo/CL_"
-#  skos: "http://www.w3.org/2004/02/skos/core"
 #mapping_provider: "http://purl.obolibrary.org/obo/FBbt.owl"
-subject_id	subject_label	predicate_id	object_id	match_type
-FBbt:00000001	organism	skos:exactMatch	UBERON:0000468	HumanCurated
-FBbt:00000002	tagma	skos:exactMatch	UBERON:6000002	HumanCurated
-FBbt:00000003	segment	skos:exactMatch	UBERON:0000914	HumanCurated
-FBbt:00000004	head	skos:exactMatch	UBERON:0000033	HumanCurated
-FBbt:00000004	head	skos:exactMatch	UBERON:6000004	HumanCurated
-FBbt:00000005	ocular segment	skos:exactMatch	UBERON:6000005	HumanCurated
-FBbt:00000006	head segment	skos:exactMatch	UBERON:6000006	HumanCurated
-FBbt:00000007	procephalic segment	skos:exactMatch	UBERON:6000007	HumanCurated
-FBbt:00000008	labral segment	skos:exactMatch	UBERON:6000008	HumanCurated
-FBbt:00000009	antennal segment	skos:exactMatch	UBERON:6000009	HumanCurated
-FBbt:00000011	gnathal segment	skos:exactMatch	UBERON:6000011	HumanCurated
-FBbt:00000014	labial segment	skos:exactMatch	UBERON:6000014	HumanCurated
-FBbt:00000015	thorax	skos:exactMatch	UBERON:6000015	HumanCurated
-FBbt:00000016	thoracic segment	skos:exactMatch	UBERON:6000016	HumanCurated
-FBbt:00000017	prothoracic segment	skos:exactMatch	UBERON:6000017	HumanCurated
-FBbt:00000018	mesothoracic segment	skos:exactMatch	UBERON:6000018	HumanCurated
-FBbt:00000019	metathoracic segment	skos:exactMatch	UBERON:6000019	HumanCurated
-FBbt:00000020	abdomen	skos:exactMatch	UBERON:6000020	HumanCurated
-FBbt:00000021	abdominal segment	skos:exactMatch	UBERON:6000021	HumanCurated
-FBbt:00000029	abdominal segment 8	skos:exactMatch	UBERON:6000029	HumanCurated
-FBbt:00000030	abdominal segment 9	skos:exactMatch	UBERON:6000030	HumanCurated
-FBbt:00000038	chorion	skos:exactMatch	UBERON:0000920	HumanCurated
-FBbt:00000042	vitelline membrane	skos:exactMatch	UBERON:0003125	HumanCurated
-FBbt:00000046	dorsal appendage	skos:exactMatch	UBERON:6000046	HumanCurated
-FBbt:00000052	embryo	skos:exactMatch	UBERON:0000922	HumanCurated
-FBbt:00000092	primordial germ cell	skos:exactMatch	CL:0000301	HumanCurated
-FBbt:00000093	ventral midline of embryo	skos:exactMatch	UBERON:0009571	HumanCurated
-FBbt:00000095	amnioserosa	skos:exactMatch	UBERON:0010302	HumanCurated
-FBbt:00000096	ventral furrow	skos:exactMatch	UBERON:6000096	HumanCurated
-FBbt:00000097	cephalic furrow	skos:exactMatch	UBERON:6000097	HumanCurated
-FBbt:00000104	mesoderm anlage	skos:exactMatch	UBERON:6000104	HumanCurated
-FBbt:00000110	germ layer	skos:exactMatch	UBERON:0000923	HumanCurated
-FBbt:00000111	ectoderm	skos:exactMatch	UBERON:0000924	HumanCurated
-FBbt:00000112	dorsal ectoderm	skos:exactMatch	UBERON:6000112	HumanCurated
-FBbt:00000119	anterior ectoderm	skos:exactMatch	UBERON:6000119	HumanCurated
-FBbt:00000123	amnioproctodeal invagination	skos:exactMatch	UBERON:0000931	HumanCurated
-FBbt:00000124	epithelial cell	skos:exactMatch	CL:0000066	HumanCurated
-FBbt:00000125	endoderm	skos:exactMatch	UBERON:0000925	HumanCurated
-FBbt:00000126	mesoderm	skos:exactMatch	UBERON:0000926	HumanCurated
-FBbt:00000128	trunk mesoderm	skos:exactMatch	UBERON:6000128	HumanCurated
-FBbt:00000130	visceral mesoderm	skos:exactMatch	UBERON:6000130	HumanCurated
-FBbt:00000136	mesectoderm	skos:exactMatch	UBERON:0000927	HumanCurated
-FBbt:00000137	embryonic tagma	skos:exactMatch	UBERON:6000137	HumanCurated
-FBbt:00000154	embryonic segment	skos:exactMatch	UBERON:6000154	HumanCurated
-FBbt:00000155	embryonic head	skos:exactMatch	UBERON:0008816	HumanCurated
-FBbt:00000157	embryonic head segment	skos:exactMatch	UBERON:6000157	HumanCurated
-FBbt:00000158	embryonic procephalic segment	skos:exactMatch	UBERON:6000158	HumanCurated
-FBbt:00000160	embryonic antennal segment	skos:exactMatch	UBERON:6000160	HumanCurated
-FBbt:00000162	embryonic gnathal segment	skos:exactMatch	UBERON:6000162	HumanCurated
-FBbt:00000165	embryonic labial segment	skos:exactMatch	UBERON:6000165	HumanCurated
-FBbt:00000166	embryonic thorax	skos:exactMatch	UBERON:6000166	HumanCurated
-FBbt:00000167	embryonic thoracic segment	skos:exactMatch	UBERON:6000167	HumanCurated
-FBbt:00000168	embryonic prothoracic segment	skos:exactMatch	UBERON:6000168	HumanCurated
-FBbt:00000169	embryonic mesothoracic segment	skos:exactMatch	UBERON:6000169	HumanCurated
-FBbt:00000170	embryonic metathoracic segment	skos:exactMatch	UBERON:6000170	HumanCurated
-FBbt:00000171	embryonic abdomen	skos:exactMatch	UBERON:6000171	HumanCurated
-FBbt:00000172	embryonic abdominal segment	skos:exactMatch	UBERON:6000172	HumanCurated
-FBbt:00000180	embryonic abdominal segment 8	skos:exactMatch	UBERON:6000180	HumanCurated
-FBbt:00000181	embryonic abdominal segment 9	skos:exactMatch	UBERON:6000181	HumanCurated
-FBbt:00000186	embryonic optic lobe primordium	skos:exactMatch	UBERON:6000186	HumanCurated
-FBbt:00000439	stomodeum	skos:exactMatch	UBERON:0000930	HumanCurated
-FBbt:00001055	presumptive embryonic/larval nervous system	skos:exactMatch	UBERON:6001055	HumanCurated
-FBbt:00001056	presumptive embryonic/larval central nervous system	skos:exactMatch	UBERON:6001056	HumanCurated
-FBbt:00001057	neurogenic region	skos:exactMatch	UBERON:0002346	HumanCurated
-FBbt:00001059	visual primordium	skos:exactMatch	UBERON:6001059	HumanCurated
-FBbt:00001060	embryonic brain	skos:exactMatch	UBERON:6001060	HumanCurated
-FBbt:00001135	proneural cluster	skos:exactMatch	UBERON:6001135	HumanCurated
-FBbt:00001648	embryonic imaginal tissue	skos:exactMatch	UBERON:6001648	HumanCurated
-FBbt:00001649	imaginal disc primordium	skos:exactMatch	UBERON:6001649	HumanCurated
-FBbt:00001650	labial disc primordium	skos:exactMatch	UBERON:6001650	HumanCurated
-FBbt:00001652	eye-antennal disc primordium	skos:exactMatch	UBERON:6001652	HumanCurated
-FBbt:00001653	dorsal thoracic disc primordium	skos:exactMatch	UBERON:6001653	HumanCurated
-FBbt:00001655	dorsal mesothoracic disc primordium	skos:exactMatch	UBERON:6001655	HumanCurated
-FBbt:00001656	dorsal metathoracic disc primordium	skos:exactMatch	UBERON:6001656	HumanCurated
-FBbt:00001657	ventral thoracic disc primordium	skos:exactMatch	UBERON:6001657	HumanCurated
-FBbt:00001658	ventral prothoracic disc primordium	skos:exactMatch	UBERON:6001658	HumanCurated
-FBbt:00001661	genital disc primordium	skos:exactMatch	UBERON:6001661	HumanCurated
-FBbt:00001662	male genital disc primordium	skos:exactMatch	UBERON:6001662	HumanCurated
-FBbt:00001663	female genital disc primordium	skos:exactMatch	UBERON:6001663	HumanCurated
-FBbt:00001664	embryonic/larval circulatory system	skos:exactMatch	UBERON:6001664	HumanCurated
-FBbt:00001666	cardioblast	skos:exactMatch	CL:0000465	HumanCurated
-FBbt:00001668	embryonic/larval lymph gland	skos:exactMatch	UBERON:6001668	HumanCurated
-FBbt:00001685	embryonic/larval plasmatocyte	skos:exactMatch	CL:0000394	HumanCurated
-FBbt:00001687	lamellocyte	skos:exactMatch	CL:0000396	HumanCurated
-FBbt:00001689	procrystal cell	skos:exactMatch	CL:0000395	HumanCurated
-FBbt:00001690	embryonic/larval crystal cell	skos:exactMatch	CL:0000715	HumanCurated
-FBbt:00001691	polygonal cell	skos:exactMatch	CL:0000398	HumanCurated
-FBbt:00001718	retrocerebral complex	skos:exactMatch	UBERON:0012325	HumanCurated
-FBbt:00001722	ring gland	skos:exactMatch	UBERON:6001722	HumanCurated
-FBbt:00001727	larva	skos:exactMatch	UBERON:0002548	HumanCurated
-FBbt:00001728	larval tagma	skos:exactMatch	UBERON:6001728	HumanCurated
-FBbt:00001729	larval segment	skos:exactMatch	UBERON:6001729	HumanCurated
-FBbt:00001730	larval head	skos:exactMatch	UBERON:6001730	HumanCurated
-FBbt:00001731	larval ocular segment	skos:exactMatch	UBERON:6001731	HumanCurated
-FBbt:00001732	larval head segment	skos:exactMatch	UBERON:6001732	HumanCurated
-FBbt:00001733	larval procephalic segment	skos:exactMatch	UBERON:6001733	HumanCurated
-FBbt:00001734	larval labral segment	skos:exactMatch	UBERON:6001734	HumanCurated
-FBbt:00001735	larval antennal segment	skos:exactMatch	UBERON:6001735	HumanCurated
-FBbt:00001737	larval gnathal segment	skos:exactMatch	UBERON:6001737	HumanCurated
-FBbt:00001740	larval labial segment	skos:exactMatch	UBERON:6001740	HumanCurated
-FBbt:00001741	larval thorax	skos:exactMatch	UBERON:6001741	HumanCurated
-FBbt:00001742	larval thoracic segment	skos:exactMatch	UBERON:6001742	HumanCurated
-FBbt:00001743	larval prothoracic segment	skos:exactMatch	UBERON:6001743	HumanCurated
-FBbt:00001744	larval mesothoracic segment	skos:exactMatch	UBERON:6001744	HumanCurated
-FBbt:00001745	larval metathoracic segment	skos:exactMatch	UBERON:6001745	HumanCurated
-FBbt:00001746	larval abdomen	skos:exactMatch	UBERON:6001746	HumanCurated
-FBbt:00001747	larval abdominal segment	skos:exactMatch	UBERON:6001747	HumanCurated
-FBbt:00001755	larval abdominal segment 8	skos:exactMatch	UBERON:6001755	HumanCurated
-FBbt:00001756	larval abdominal segment 9	skos:exactMatch	UBERON:6001756	HumanCurated
-FBbt:00001760	larval imaginal tissue	skos:exactMatch	UBERON:6001760	HumanCurated
-FBbt:00001761	imaginal disc	skos:exactMatch	UBERON:0000939	HumanCurated
-FBbt:00001764	labial disc	skos:exactMatch	UBERON:6001764	HumanCurated
-FBbt:00001765	clypeo-labral disc	skos:exactMatch	UBERON:6001765	HumanCurated
-FBbt:00001766	eye-antennal disc	skos:exactMatch	UBERON:6001766	HumanCurated
-FBbt:00001767	antennal disc	skos:exactMatch	UBERON:6001767	HumanCurated
-FBbt:00001776	dorsal thoracic disc	skos:exactMatch	UBERON:6001776	HumanCurated
-FBbt:00001778	wing disc	skos:exactMatch	UBERON:6001778	HumanCurated
-FBbt:00001779	haltere disc	skos:exactMatch	UBERON:6001779	HumanCurated
-FBbt:00001780	ventral thoracic disc	skos:exactMatch	UBERON:6001780	HumanCurated
-FBbt:00001781	prothoracic leg disc	skos:exactMatch	UBERON:6001781	HumanCurated
-FBbt:00001784	genital disc	skos:exactMatch	UBERON:6001784	HumanCurated
-FBbt:00001785	male genital disc	skos:exactMatch	UBERON:6001785	HumanCurated
-FBbt:00001787	female genital disc	skos:exactMatch	UBERON:6001787	HumanCurated
-FBbt:00001789	histoblast	skos:exactMatch	CL:0000373	HumanCurated
-FBbt:00001789	histoblast	skos:exactMatch	UBERON:6001789	HumanCurated
-FBbt:00001790	histoblast nest	skos:exactMatch	UBERON:6001790	HumanCurated
-FBbt:00001791	dorsal histoblast nest abdominal	skos:exactMatch	UBERON:6001791	HumanCurated
-FBbt:00001792	anterior dorsal histoblast nest abdominal	skos:exactMatch	UBERON:6001792	HumanCurated
-FBbt:00001809	posterior dorsal histoblast nest abdominal	skos:exactMatch	UBERON:6001809	HumanCurated
-FBbt:00001842	embryonic/larval digestive system	skos:exactMatch	UBERON:6001842	HumanCurated
-FBbt:00001845	cephalopharyngeal skeleton	skos:exactMatch	UBERON:6001845	HumanCurated
-FBbt:00001848	epipharyngeal sclerite	skos:exactMatch	UBERON:6001848	HumanCurated
-FBbt:00001911	embryonic/larval nervous system	skos:exactMatch	UBERON:6001911	HumanCurated
-FBbt:00001919	embryonic/larval central nervous system	skos:exactMatch	UBERON:6001919	HumanCurated
-FBbt:00001920	embryonic/larval brain	skos:exactMatch	UBERON:6001920	HumanCurated
-FBbt:00001925	embryonic/larval protocerebrum	skos:exactMatch	UBERON:6001925	HumanCurated
-FBbt:00001956	optic nerve	skos:exactMatch	UBERON:0004904	HumanCurated
-FBbt:00002639	embryonic/larval sense organ	skos:exactMatch	UBERON:6002639	HumanCurated
-FBbt:00002642	embryonic/larval ocular segment sensillum	skos:exactMatch	UBERON:6002642	HumanCurated
-FBbt:00002952	prepupa	skos:exactMatch	UBERON:0003142	HumanCurated
-FBbt:00002953	pupa	skos:exactMatch	UBERON:0003143	HumanCurated
-FBbt:00003004	adult	skos:exactMatch	UBERON:0007023	HumanCurated
-FBbt:00003005	adult tagma	skos:exactMatch	UBERON:6003005	HumanCurated
-FBbt:00003006	adult segment	skos:exactMatch	UBERON:6003006	HumanCurated
-FBbt:00003007	adult head	skos:exactMatch	UBERON:6003007	HumanCurated
-FBbt:00003009	adult head segment	skos:exactMatch	UBERON:6003009	HumanCurated
-FBbt:00003010	adult procephalic segment	skos:exactMatch	UBERON:6003010	HumanCurated
-FBbt:00003011	adult labral segment	skos:exactMatch	UBERON:6003011	HumanCurated
-FBbt:00003012	adult antennal segment	skos:exactMatch	UBERON:6003012	HumanCurated
-FBbt:00003018	adult thorax	skos:exactMatch	UBERON:6003018	HumanCurated
-FBbt:00003019	adult thoracic segment	skos:exactMatch	UBERON:6003019	HumanCurated
-FBbt:00003020	adult prothoracic segment	skos:exactMatch	UBERON:6003020	HumanCurated
-FBbt:00003021	adult mesothoracic segment	skos:exactMatch	UBERON:6003021	HumanCurated
-FBbt:00003023	adult abdomen	skos:exactMatch	UBERON:6003023	HumanCurated
-FBbt:00003024	adult abdominal segment	skos:exactMatch	UBERON:6003024	HumanCurated
-FBbt:00003039	adult dorsal trunk	skos:exactMatch	UBERON:6003039	HumanCurated
-FBbt:00003125	alimentary canal	skos:exactMatch	UBERON:0001555	HumanCurated
-FBbt:00003126	adult mouth	skos:exactMatch	UBERON:0000165	HumanCurated
-FBbt:00003154	adult heart	skos:exactMatch	UBERON:0015230	HumanCurated
-FBbt:00003219	adepithelial cell	skos:exactMatch	CL:0000462	HumanCurated
-FBbt:00003259	adult somatic muscle	skos:exactMatch	UBERON:6003259	HumanCurated
-FBbt:00003559	adult nervous system	skos:exactMatch	UBERON:6003559	HumanCurated
-FBbt:00003623	adult central nervous system	skos:exactMatch	UBERON:6003623	HumanCurated
-FBbt:00003624	adult brain	skos:exactMatch	UBERON:6003624	HumanCurated
-FBbt:00003626	supraesophageal ganglion	skos:exactMatch	UBERON:6003626	HumanCurated
-FBbt:00003627	protocerebrum	skos:exactMatch	UBERON:6003627	HumanCurated
-FBbt:00003632	adult central complex	skos:exactMatch	UBERON:6003632	HumanCurated
-FBbt:00003701	adult optic lobe	skos:exactMatch	UBERON:0006795	HumanCurated
-FBbt:00004114	head sensillum	skos:exactMatch	UBERON:0000963	HumanCurated
-FBbt:00004193	cone cell	skos:exactMatch	CL:0000718	HumanCurated
-FBbt:00004199	lens	skos:exactMatch	UBERON:0000207	HumanCurated
-FBbt:00004200	retina	skos:exactMatch	UBERON:0005388	HumanCurated
-FBbt:00004203	adult clypeo-labral anlage	skos:exactMatch	UBERON:6004203	HumanCurated
-FBbt:00004208	developing embryonic structure	skos:exactMatch	UBERON:0002050	HumanCurated
-FBbt:00004211	photoreceptor cell	skos:exactMatch	CL:2000019	HumanCurated
-FBbt:00004230	pigment cell	skos:exactMatch	CL:0001658	HumanCurated
-FBbt:00004296	sex comb	skos:exactMatch	UBERON:6004296	HumanCurated
-FBbt:00004340	wing hair	skos:exactMatch	UBERON:6004340	HumanCurated
-FBbt:00004475	sclerite	skos:exactMatch	UBERON:6004475	HumanCurated
-FBbt:00004476	tergite	skos:exactMatch	UBERON:6004476	HumanCurated
-FBbt:00004477	sternite	skos:exactMatch	UBERON:6004477	HumanCurated
-FBbt:00004481	adult external head	skos:exactMatch	UBERON:6004481	HumanCurated
-FBbt:00004492	occiput	skos:exactMatch	UBERON:0003155	HumanCurated
-FBbt:00004505	ocellus	skos:exactMatch	UBERON:0003161	HumanCurated
-FBbt:00004506	lateral ocellus	skos:exactMatch	UBERON:0003162	HumanCurated
-FBbt:00004507	medial ocellus	skos:exactMatch	UBERON:0003211	HumanCurated
-FBbt:00004508	eye	skos:exactMatch	UBERON:0000018	HumanCurated
-FBbt:00004510	ommatidium	skos:exactMatch	UBERON:0000971	HumanCurated
-FBbt:00004511	antenna	skos:exactMatch	UBERON:0000972	HumanCurated
-FBbt:00004519	arista	skos:exactMatch	UBERON:6004519	HumanCurated
-FBbt:00004520	mouthpart	skos:exactMatch	UBERON:6004520	HumanCurated
-FBbt:00004521	clypeus	skos:exactMatch	UBERON:6004521	HumanCurated
-FBbt:00004522	labrum	skos:exactMatch	UBERON:0005905	HumanCurated
-FBbt:00004535	proboscis	skos:exactMatch	UBERON:6004535	HumanCurated
-FBbt:00004540	rostrum	skos:exactMatch	UBERON:6004540	HumanCurated
-FBbt:00004551	adult external thorax	skos:exactMatch	UBERON:6004551	HumanCurated
-FBbt:00004552	tergum	skos:exactMatch	UBERON:6004552	HumanCurated
-FBbt:00004557	sternum	skos:exactMatch	UBERON:0003130	HumanCurated
-FBbt:00004578	adult external mesothorax	skos:exactMatch	UBERON:6004578	HumanCurated
-FBbt:00004579	dorsal mesothorax	skos:exactMatch	UBERON:6004579	HumanCurated
-FBbt:00004580	mesothoracic tergum	skos:exactMatch	UBERON:6004580	HumanCurated
-FBbt:00004640	leg	skos:exactMatch	UBERON:0005895	HumanCurated
-FBbt:00004642	tibia	skos:exactMatch	UBERON:0003131	HumanCurated
-FBbt:00004646	tarsal segment	skos:exactMatch	UBERON:6004646	HumanCurated
-FBbt:00004648	metatarsus	skos:exactMatch	UBERON:6004648	HumanCurated
-FBbt:00004663	prothoracic leg	skos:exactMatch	UBERON:6004663	HumanCurated
-FBbt:00004668	prothoracic tarsal segment	skos:exactMatch	UBERON:6004668	HumanCurated
-FBbt:00004670	prothoracic metatarsus	skos:exactMatch	UBERON:6004670	HumanCurated
-FBbt:00004729	wing	skos:exactMatch	UBERON:0000984	HumanCurated
-FBbt:00004751	wing vein	skos:exactMatch	UBERON:0003194	HumanCurated
-FBbt:00004783	haltere	skos:exactMatch	UBERON:0000987	HumanCurated
-FBbt:00004788	adult external abdomen	skos:exactMatch	UBERON:6004788	HumanCurated
-FBbt:00004823	analia	skos:exactMatch	UBERON:6004823	HumanCurated
-FBbt:00004824	female analia	skos:exactMatch	UBERON:6004824	HumanCurated
-FBbt:00004825	male analia	skos:exactMatch	UBERON:6004825	HumanCurated
-FBbt:00004850	phallus	skos:exactMatch	UBERON:0008811	HumanCurated
-FBbt:00004856	organ system	skos:exactMatch	UBERON:0000467	HumanCurated
-FBbt:00004857	reproductive system	skos:exactMatch	UBERON:0000990	HumanCurated
-FBbt:00004858	gonad	skos:exactMatch	UBERON:0000991	HumanCurated
-FBbt:00004861	germline stem cell	skos:exactMatch	CL:0000086	HumanCurated
-FBbt:00004864	female reproductive system	skos:exactMatch	UBERON:0000474	HumanCurated
-FBbt:00004865	ovary	skos:exactMatch	UBERON:0000992	HumanCurated
-FBbt:00004873	female germline stem cell	skos:exactMatch	CL:0000022	HumanCurated
-FBbt:00004878	nurse cell	skos:exactMatch	CL:0000026	HumanCurated
-FBbt:00004886	oocyte	skos:exactMatch	CL:0000023	HumanCurated
-FBbt:00004894	egg chamber	skos:exactMatch	UBERON:0003199	HumanCurated
-FBbt:00004903	follicle stem cell	skos:exactMatch	CL:0000441	HumanCurated
-FBbt:00004904	follicle cell	skos:exactMatch	CL:0000477	HumanCurated
-FBbt:00004905	border follicle cell	skos:exactMatch	CL:0000579	HumanCurated
-FBbt:00004906	centripetal follicle cell	skos:exactMatch	CL:0000671	HumanCurated
-FBbt:00004910	stalk follicle cell	skos:exactMatch	CL:0000674	HumanCurated
-FBbt:00004921	spermathecum	skos:exactMatch	UBERON:0000994	HumanCurated
-FBbt:00004924	uterus	skos:exactMatch	UBERON:0006834	HumanCurated
-FBbt:00004927	male reproductive system	skos:exactMatch	UBERON:0000079	HumanCurated
-FBbt:00004928	testis	skos:exactMatch	UBERON:0000473	HumanCurated
-FBbt:00004929	male germline stem cell	skos:exactMatch	CL:0000087	HumanCurated
-FBbt:00004934	primary gonial cell	skos:exactMatch	CL:0000020	HumanCurated
-FBbt:00004935	spermatogonium	skos:exactMatch	CL:0000020	HumanCurated
-FBbt:00004936	spermatocyte	skos:exactMatch	CL:0000017	HumanCurated
-FBbt:00004941	secondary spermatocyte	skos:exactMatch	CL:0000657	HumanCurated
-FBbt:00004942	spermatid	skos:exactMatch	CL:0000018	HumanCurated
-FBbt:00004954	spermatozoon	skos:exactMatch	CL:0000019	HumanCurated
-FBbt:00004958	seminal vesicle	skos:exactMatch	UBERON:0006868	HumanCurated
-FBbt:00004969	integumentary system	skos:exactMatch	UBERON:0002416	HumanCurated
-FBbt:00004970	cuticle	skos:exactMatch	UBERON:0001001	HumanCurated
-FBbt:00004973	exocuticle	skos:exactMatch	UBERON:0003201	HumanCurated
-FBbt:00004974	endocuticle	skos:exactMatch	UBERON:0003202	HumanCurated
-FBbt:00004979	trichome	skos:exactMatch	UBERON:6004979	HumanCurated
-FBbt:00004983	embryonic/larval cuticle	skos:exactMatch	UBERON:6004983	HumanCurated
-FBbt:00004986	third instar larval cuticle	skos:exactMatch	UBERON:6004986	HumanCurated
-FBbt:00004987	puparium cuticle	skos:exactMatch	UBERON:0018656	HumanCurated
-FBbt:00004993	epidermis	skos:exactMatch	UBERON:0007376	HumanCurated
-FBbt:00004994	epidermoblast	skos:exactMatch	CL:0000464	HumanCurated
-FBbt:00004995	oenocyte	skos:exactMatch	CL:0000487	HumanCurated
-FBbt:00005023	imaginal precursor	skos:exactMatch	UBERON:6005023	HumanCurated
-FBbt:00005024	tracheal system	skos:exactMatch	UBERON:0005155	HumanCurated
-FBbt:00005036	tracheal pit	skos:exactMatch	UBERON:6005036	HumanCurated
-FBbt:00005037	tracheal primordium	skos:exactMatch	UBERON:6005037	HumanCurated
-FBbt:00005038	tracheocyte	skos:exactMatch	CL:0000307	HumanCurated
-FBbt:00005043	trachea	skos:exactMatch	UBERON:6005043	HumanCurated
-FBbt:00005054	spiracle	skos:exactMatch	UBERON:6005054	HumanCurated
-FBbt:00005055	digestive system	skos:exactMatch	UBERON:0001007	HumanCurated
-FBbt:00005056	excretory system	skos:exactMatch	UBERON:0001008	HumanCurated
-FBbt:00005057	circulatory system	skos:exactMatch	UBERON:0009054	HumanCurated
-FBbt:00005058	pericardial cell	skos:exactMatch	CL:0000474	HumanCurated
-FBbt:00005059	garland cell	skos:exactMatch	CL:0000486	HumanCurated
-FBbt:00005060	hemocoel	skos:exactMatch	UBERON:0002323	HumanCurated
-FBbt:00005061	hemolymph	skos:exactMatch	UBERON:0001011	HumanCurated
-FBbt:00005062	prohemocyte	skos:exactMatch	CL:0000385	HumanCurated
-FBbt:00005063	hemocyte	skos:exactMatch	CL:0000387	HumanCurated
-FBbt:00005066	fat body	skos:exactMatch	UBERON:0003917	HumanCurated
-FBbt:00005068	endocrine system	skos:exactMatch	UBERON:0000949	HumanCurated
-FBbt:00005070	visceral muscle cell	skos:exactMatch	CL:0008007	HumanCurated
-FBbt:00005073	somatic muscle cell	skos:exactMatch	CL:0008004	HumanCurated
-FBbt:00005074	muscle cell	skos:exactMatch	CL:0000187	HumanCurated
-FBbt:00005083	myoblast	skos:exactMatch	CL:0000056	HumanCurated
-FBbt:00005093	nervous system	skos:exactMatch	UBERON:0001016	HumanCurated
-FBbt:00005094	central nervous system	skos:exactMatch	UBERON:0001017	HumanCurated
-FBbt:00005095	brain	skos:exactMatch	UBERON:0000955	HumanCurated
-FBbt:00005096	stomatogastric nervous system	skos:exactMatch	UBERON:6005096	HumanCurated
-FBbt:00005097	ventral nerve cord	skos:exactMatch	UBERON:0000934	HumanCurated
-FBbt:00005098	peripheral nervous system	skos:exactMatch	UBERON:0000010	HumanCurated
-FBbt:00005099	neuron projection bundle	skos:exactMatch	UBERON:0000122	HumanCurated
-FBbt:00005100	tract	skos:exactMatch	UBERON:0001018	HumanCurated
-FBbt:00005105	nerve	skos:exactMatch	UBERON:0001021	HumanCurated
-FBbt:00005106	neuron	skos:exactMatch	CL:0000540	HumanCurated
-FBbt:00005123	motor neuron	skos:exactMatch	CL:0000100	HumanCurated
-FBbt:00005124	sensory neuron	skos:exactMatch	CL:0000101	HumanCurated
-FBbt:00005125	interneuron	skos:exactMatch	CL:0000099	HumanCurated
-FBbt:00005128	pioneer neuron	skos:exactMatch	CL:0000116	HumanCurated
-FBbt:00005130	neurosecretory neuron	skos:exactMatch	CL:0000381	HumanCurated
-FBbt:00005133	serotonergic neuron	skos:exactMatch	CL:0000850	HumanCurated
-FBbt:00005136	sensory nerve	skos:exactMatch	UBERON:0001027	HumanCurated
-FBbt:00005139	neuropil	skos:exactMatch	UBERON:0002606	HumanCurated
-FBbt:00005144	glial cell	skos:exactMatch	CL:0000125	HumanCurated
-FBbt:00005145	glioblast	skos:exactMatch	CL:0000340	HumanCurated
-FBbt:00005146	neuroblast	skos:exactMatch	CL:0000338	HumanCurated
-FBbt:00005147	neuroglioblast	skos:exactMatch	CL:0000468	HumanCurated
-FBbt:00005148	neuroepidermoblast	skos:exactMatch	CL:0000405	HumanCurated
-FBbt:00005149	ganglion mother cell	skos:exactMatch	CL:0000469	HumanCurated
-FBbt:00005155	sense organ	skos:exactMatch	UBERON:0000020	HumanCurated
-FBbt:00005157	chemosensory sensory organ	skos:exactMatch	UBERON:0000005	HumanCurated
-FBbt:00005158	olfactory sensory organ	skos:exactMatch	UBERON:0002268	HumanCurated
-FBbt:00005159	gustatory sensory organ	skos:exactMatch	UBERON:0003212	HumanCurated
-FBbt:00005162	photoreceptor	skos:exactMatch	UBERON:0000970	HumanCurated
-FBbt:00005168	external sensory organ	skos:exactMatch	UBERON:6005168	HumanCurated
-FBbt:00005169	trichogen cell	skos:exactMatch	CL:0000374	HumanCurated
-FBbt:00005171	tormogen cell	skos:exactMatch	CL:0000372	HumanCurated
-FBbt:00005177	chaeta	skos:exactMatch	UBERON:6005177	HumanCurated
-FBbt:00005215	chordotonal organ	skos:exactMatch	UBERON:0001038	HumanCurated
-FBbt:00005219	scolopale cell	skos:exactMatch	CL:0000382	HumanCurated
-FBbt:00005221	scolopidial ligament cell	skos:exactMatch	CL:0000407	HumanCurated
-FBbt:00005317	gastrula embryo	skos:exactMatch	UBERON:0004734	HumanCurated
-FBbt:00005333	late embryo	skos:exactMatch	UBERON:0000323	HumanCurated
-FBbt:00005338	second instar larva	skos:exactMatch	UBERON:0018382	HumanCurated
-FBbt:00005378	wing margin	skos:exactMatch	UBERON:6005378	HumanCurated
-FBbt:00005379	foregut	skos:exactMatch	UBERON:0001041	HumanCurated
-FBbt:00005380	pharynx	skos:exactMatch	UBERON:0006562	HumanCurated
-FBbt:00005382	salivary gland	skos:exactMatch	UBERON:0001044	HumanCurated
-FBbt:00005383	midgut	skos:exactMatch	UBERON:0001045	HumanCurated
-FBbt:00005384	hindgut	skos:exactMatch	UBERON:0001046	HumanCurated
-FBbt:00005386	glomerulus	skos:exactMatch	UBERON:0001047	HumanCurated
-FBbt:00005393	embryonic/larval integumentary system	skos:exactMatch	UBERON:6005393	HumanCurated
-FBbt:00005396	adult integumentary system	skos:exactMatch	UBERON:6005396	HumanCurated
-FBbt:00005412	gamete	skos:exactMatch	CL:0000300	HumanCurated
-FBbt:00005413	anlage in statu nascendi	skos:exactMatch	UBERON:6005413	HumanCurated
-FBbt:00005426	anlage	skos:exactMatch	UBERON:0007688	HumanCurated
-FBbt:00005427	ectoderm anlage	skos:exactMatch	UBERON:6005427	HumanCurated
-FBbt:00005428	dorsal ectoderm anlage	skos:exactMatch	UBERON:6005428	HumanCurated
-FBbt:00005434	visual anlage	skos:exactMatch	UBERON:6005434	HumanCurated
-FBbt:00005436	trunk mesoderm anlage	skos:exactMatch	UBERON:6005436	HumanCurated
-FBbt:00005439	clypeo-labral anlage	skos:exactMatch	UBERON:6005439	HumanCurated
-FBbt:00005461	circulatory system primordium	skos:exactMatch	UBERON:6005461	HumanCurated
-FBbt:00005467	lymph gland primordium	skos:exactMatch	UBERON:6005467	HumanCurated
-FBbt:00005495	primordium	skos:exactMatch	UBERON:0001048	HumanCurated
-FBbt:00005514	clypeo-labral disc primordium	skos:exactMatch	UBERON:6005514	HumanCurated
-FBbt:00005526	dorsal epidermis primordium	skos:exactMatch	UBERON:6005526	HumanCurated
-FBbt:00005533	ventral epidermis primordium	skos:exactMatch	UBERON:6005533	HumanCurated
-FBbt:00005538	clypeo-labral primordium	skos:exactMatch	UBERON:6005538	HumanCurated
-FBbt:00005558	ventral ectoderm	skos:exactMatch	UBERON:6005558	HumanCurated
-FBbt:00005569	presumptive embryonic/larval tracheal system	skos:exactMatch	UBERON:6005569	HumanCurated
-FBbt:00005756	rectum	skos:exactMatch	UBERON:0006866	HumanCurated
-FBbt:00005757	neurohemal organ	skos:exactMatch	UBERON:0001053	HumanCurated
-FBbt:00005786	Malpighian tubule	skos:exactMatch	UBERON:0001054	HumanCurated
-FBbt:00005797	Malpighian tubule Type II cell	skos:exactMatch	CL:1000155	HumanCurated
-FBbt:00005799	corpus cardiacum	skos:exactMatch	UBERON:0001056	HumanCurated
-FBbt:00005800	corpus allatum	skos:exactMatch	UBERON:0001057	HumanCurated
-FBbt:00005801	mushroom body	skos:exactMatch	UBERON:0001058	HumanCurated
-FBbt:00005802	pars intercerebralis	skos:exactMatch	UBERON:0001059	HumanCurated
-FBbt:00005805	Bolwig organ	skos:exactMatch	UBERON:6005805	HumanCurated
-FBbt:00005811	articulation	skos:exactMatch	UBERON:0004905	HumanCurated
-FBbt:00005812	myotube	skos:exactMatch	CL:0002372	HumanCurated
-FBbt:00005830	Bolwig organ primordium	skos:exactMatch	UBERON:6005830	HumanCurated
-FBbt:00005831	dorsal imaginal tissue	skos:exactMatch	UBERON:6005831	HumanCurated
-FBbt:00005835	extraembryonic structure	skos:exactMatch	UBERON:0000478	HumanCurated
-FBbt:00005913	arista lateral	skos:exactMatch	UBERON:6005913	HumanCurated
-FBbt:00005917	lymph gland derived hemocyte	skos:exactMatch	CL:0000735	HumanCurated
-FBbt:00006011	pharate adult	skos:exactMatch	UBERON:6006011	HumanCurated
-FBbt:00006032	mesothoracic tergum primordium	skos:exactMatch	UBERON:6006032	HumanCurated
-FBbt:00007000	appendage	skos:exactMatch	UBERON:0000026	HumanCurated
-FBbt:00007001	anatomical structure	skos:exactMatch	UBERON:0000061	HumanCurated
-FBbt:00007002	cell	skos:exactMatch	CL:0000000	HumanCurated
-FBbt:00007003	portion of tissue	skos:exactMatch	UBERON:0000479	HumanCurated
-FBbt:00007004	male organism	skos:exactMatch	UBERON:0003101	HumanCurated
-FBbt:00007005	epithelium	skos:exactMatch	UBERON:0000483	HumanCurated
-FBbt:00007006	developing material anatomical entity	skos:exactMatch	UBERON:0005423	HumanCurated
-FBbt:00007009	organism subdivision	skos:exactMatch	UBERON:0000475	HumanCurated
-FBbt:00007010	multi-tissue structure	skos:exactMatch	UBERON:0000481	HumanCurated
-FBbt:00007011	female organism	skos:exactMatch	UBERON:0003100	HumanCurated
-FBbt:00007013	acellular anatomical structure	skos:exactMatch	UBERON:0000476	HumanCurated
-FBbt:00007015	immaterial anatomical entity	skos:exactMatch	UBERON:0000466	HumanCurated
-FBbt:00007016	material anatomical entity	skos:exactMatch	UBERON:0000465	HumanCurated
-FBbt:00007017	anatomical space	skos:exactMatch	UBERON:0000464	HumanCurated
-FBbt:00007018	appendage segment	skos:exactMatch	UBERON:0010758	HumanCurated
-FBbt:00007019	portion of organism substance	skos:exactMatch	UBERON:0000463	HumanCurated
-FBbt:00007020	metatarsus of male prothoracic leg	skos:exactMatch	UBERON:6007020	HumanCurated
-FBbt:00007027	cuboidal/columnar epithelium	skos:exactMatch	UBERON:0000485	HumanCurated
-FBbt:00007045	trunk ectoderm	skos:exactMatch	UBERON:6007045	HumanCurated
-FBbt:00007046	dorsal ectoderm derivative	skos:exactMatch	UBERON:6007046	HumanCurated
-FBbt:00007060	multi-cell-component structure	skos:exactMatch	UBERON:0005162	HumanCurated
-FBbt:00007070	embryonic/larval posterior inferior protocerebrum	skos:exactMatch	UBERON:6007070	HumanCurated
-FBbt:00007091	subperineurial glial sheath	skos:exactMatch	UBERON:0000202	HumanCurated
-FBbt:00007116	presumptive embryonic/larval system	skos:exactMatch	UBERON:6007116	HumanCurated
-FBbt:00007145	adult protocerebrum	skos:exactMatch	UBERON:6007145	HumanCurated
-FBbt:00007149	segment of antenna	skos:exactMatch	UBERON:6007149	HumanCurated
-FBbt:00007150	segment of leg	skos:exactMatch	UBERON:6007150	HumanCurated
-FBbt:00007152	sensillum	skos:exactMatch	UBERON:0002536	HumanCurated
-FBbt:00007229	cell cluster organ	skos:exactMatch	UBERON:0010001	HumanCurated
-FBbt:00007230	compound cell cluster organ	skos:exactMatch	UBERON:0014732	HumanCurated
-FBbt:00007231	external sensillum	skos:exactMatch	UBERON:6007231	HumanCurated
-FBbt:00007232	eo-type sensillum	skos:exactMatch	UBERON:6007232	HumanCurated
-FBbt:00007233	internal sensillum	skos:exactMatch	UBERON:6007233	HumanCurated
-FBbt:00007240	embryonic/larval sensillum	skos:exactMatch	UBERON:6007240	HumanCurated
-FBbt:00007242	embryonic/larval head sensillum	skos:exactMatch	UBERON:6007242	HumanCurated
-FBbt:00007245	cuticular specialization	skos:exactMatch	UBERON:6007245	HumanCurated
-FBbt:00007248	chorionic specialization	skos:exactMatch	UBERON:6007248	HumanCurated
-FBbt:00007276	anatomical group	skos:exactMatch	UBERON:0034923	HumanCurated
-FBbt:00007277	anatomical cluster	skos:exactMatch	UBERON:0000477	HumanCurated
-FBbt:00007278	non-connected functional system	skos:exactMatch	UBERON:0015203	HumanCurated
-FBbt:00007280	embryonic/larval head sense organ	skos:exactMatch	UBERON:6007280	HumanCurated
-FBbt:00007284	region of integument	skos:exactMatch	UBERON:6007284	HumanCurated
-FBbt:00007285	segmental subdivision of integument	skos:exactMatch	UBERON:6007285	HumanCurated
-FBbt:00007288	integumentary specialization	skos:exactMatch	UBERON:6007288	HumanCurated
-FBbt:00007289	tagmatic subdivision of integument	skos:exactMatch	UBERON:6007289	HumanCurated
-FBbt:00007325	epidermal cell	skos:exactMatch	CL:0000463	HumanCurated
-FBbt:00007330	organ system subdivision	skos:exactMatch	UBERON:0011216	HumanCurated
-FBbt:00007331	segmental subdivision of organ system	skos:exactMatch	UBERON:6007331	HumanCurated
-FBbt:00007373	internal sense organ	skos:exactMatch	UBERON:6007373	HumanCurated
-FBbt:00007410	tracheal lumen	skos:exactMatch	UBERON:0006832	HumanCurated
-FBbt:00007424	epithelial furrow	skos:exactMatch	UBERON:6007424	HumanCurated
-FBbt:00007474	epithelial tube	skos:exactMatch	UBERON:0003914	HumanCurated
-FBbt:00007692	sensory system	skos:exactMatch	UBERON:0001032	HumanCurated
-FBbt:00016022	abdominal histoblast primordium	skos:exactMatch	UBERON:6016022	HumanCurated
-FBbt:00017021	abdominal histoblast anlage	skos:exactMatch	UBERON:6017021	HumanCurated
-FBbt:00040003	non-connected developing system	skos:exactMatch	UBERON:6040003	HumanCurated
-FBbt:00040005	synaptic neuropil	skos:exactMatch	UBERON:6040005	HumanCurated
-FBbt:00040007	synaptic neuropil domain	skos:exactMatch	UBERON:6040007	HumanCurated
-FBbt:00041000	synaptic neuropil block	skos:exactMatch	UBERON:6041000	HumanCurated
-FBbt:00047153	anus	skos:exactMatch	UBERON:0001245	HumanCurated
-FBbt:00057001	anterior-posterior subdivision of organism	skos:exactMatch	UBERON:6057001	HumanCurated
-FBbt:00057012	female germline cell	skos:exactMatch	CL:0000025	HumanCurated
-FBbt:00058291	dorsal vessel	skos:exactMatch	UBERON:0015231	HumanCurated
-FBbt:00100152	row	skos:exactMatch	UBERON:0034926	HumanCurated
-FBbt:00100153	sensillum row	skos:exactMatch	UBERON:6100153	HumanCurated
-FBbt:00100313	multicellular structure	skos:exactMatch	UBERON:0010000	HumanCurated
-FBbt:00100314	duct	skos:exactMatch	UBERON:0000058	HumanCurated
-FBbt:00100315	gut section	skos:exactMatch	UBERON:0004921	HumanCurated
-FBbt:00100316	diverticulum of gut	skos:exactMatch	UBERON:0009854	HumanCurated
-FBbt:00100317	gland	skos:exactMatch	UBERON:0002530	HumanCurated
-FBbt:00110636	adult cerebral ganglion	skos:exactMatch	UBERON:6110636	HumanCurated
-FBbt:00110746	presumptive prothoracic metatarsus	skos:exactMatch	UBERON:6110746	HumanCurated
-FBbt:00110811	presumptive arista	skos:exactMatch	UBERON:6110811	HumanCurated
-FBbt:10000000	anatomical entity	skos:exactMatch	UBERON:0001062	HumanCurated
+subject_id	subject_label	predicate_id	object_id	mapping_justification
+FBbt:00000001	organism	semapv:crossSpeciesExactMatch	UBERON:0000468	semapv:ManualMappingCuration
+FBbt:00000002	tagma	semapv:crossSpeciesExactMatch	UBERON:6000002	semapv:ManualMappingCuration
+FBbt:00000003	segment	semapv:crossSpeciesExactMatch	UBERON:0000914	semapv:ManualMappingCuration
+FBbt:00000004	head	semapv:crossSpeciesExactMatch	UBERON:0000033	semapv:ManualMappingCuration
+FBbt:00000004	head	semapv:crossSpeciesExactMatch	UBERON:6000004	semapv:ManualMappingCuration
+FBbt:00000005	ocular segment	semapv:crossSpeciesExactMatch	UBERON:6000005	semapv:ManualMappingCuration
+FBbt:00000006	head segment	semapv:crossSpeciesExactMatch	UBERON:6000006	semapv:ManualMappingCuration
+FBbt:00000007	procephalic segment	semapv:crossSpeciesExactMatch	UBERON:6000007	semapv:ManualMappingCuration
+FBbt:00000008	labral segment	semapv:crossSpeciesExactMatch	UBERON:6000008	semapv:ManualMappingCuration
+FBbt:00000009	antennal segment	semapv:crossSpeciesExactMatch	UBERON:6000009	semapv:ManualMappingCuration
+FBbt:00000011	gnathal segment	semapv:crossSpeciesExactMatch	UBERON:6000011	semapv:ManualMappingCuration
+FBbt:00000014	labial segment	semapv:crossSpeciesExactMatch	UBERON:6000014	semapv:ManualMappingCuration
+FBbt:00000015	thorax	semapv:crossSpeciesExactMatch	UBERON:6000015	semapv:ManualMappingCuration
+FBbt:00000016	thoracic segment	semapv:crossSpeciesExactMatch	UBERON:6000016	semapv:ManualMappingCuration
+FBbt:00000017	prothoracic segment	semapv:crossSpeciesExactMatch	UBERON:6000017	semapv:ManualMappingCuration
+FBbt:00000018	mesothoracic segment	semapv:crossSpeciesExactMatch	UBERON:6000018	semapv:ManualMappingCuration
+FBbt:00000019	metathoracic segment	semapv:crossSpeciesExactMatch	UBERON:6000019	semapv:ManualMappingCuration
+FBbt:00000020	abdomen	semapv:crossSpeciesExactMatch	UBERON:6000020	semapv:ManualMappingCuration
+FBbt:00000021	abdominal segment	semapv:crossSpeciesExactMatch	UBERON:6000021	semapv:ManualMappingCuration
+FBbt:00000029	abdominal segment 8	semapv:crossSpeciesExactMatch	UBERON:6000029	semapv:ManualMappingCuration
+FBbt:00000030	abdominal segment 9	semapv:crossSpeciesExactMatch	UBERON:6000030	semapv:ManualMappingCuration
+FBbt:00000038	chorion	semapv:crossSpeciesExactMatch	UBERON:0000920	semapv:ManualMappingCuration
+FBbt:00000042	vitelline membrane	semapv:crossSpeciesExactMatch	UBERON:0003125	semapv:ManualMappingCuration
+FBbt:00000046	dorsal appendage	semapv:crossSpeciesExactMatch	UBERON:6000046	semapv:ManualMappingCuration
+FBbt:00000052	embryo	semapv:crossSpeciesExactMatch	UBERON:0000922	semapv:ManualMappingCuration
+FBbt:00000092	primordial germ cell	semapv:crossSpeciesExactMatch	CL:0000301	semapv:ManualMappingCuration
+FBbt:00000093	ventral midline of embryo	semapv:crossSpeciesExactMatch	UBERON:0009571	semapv:ManualMappingCuration
+FBbt:00000095	amnioserosa	semapv:crossSpeciesExactMatch	UBERON:0010302	semapv:ManualMappingCuration
+FBbt:00000096	ventral furrow	semapv:crossSpeciesExactMatch	UBERON:6000096	semapv:ManualMappingCuration
+FBbt:00000097	cephalic furrow	semapv:crossSpeciesExactMatch	UBERON:6000097	semapv:ManualMappingCuration
+FBbt:00000104	mesoderm anlage	semapv:crossSpeciesExactMatch	UBERON:6000104	semapv:ManualMappingCuration
+FBbt:00000110	germ layer	semapv:crossSpeciesExactMatch	UBERON:0000923	semapv:ManualMappingCuration
+FBbt:00000111	ectoderm	semapv:crossSpeciesExactMatch	UBERON:0000924	semapv:ManualMappingCuration
+FBbt:00000112	dorsal ectoderm	semapv:crossSpeciesExactMatch	UBERON:6000112	semapv:ManualMappingCuration
+FBbt:00000119	anterior ectoderm	semapv:crossSpeciesExactMatch	UBERON:6000119	semapv:ManualMappingCuration
+FBbt:00000123	amnioproctodeal invagination	semapv:crossSpeciesExactMatch	UBERON:0000931	semapv:ManualMappingCuration
+FBbt:00000124	epithelial cell	semapv:crossSpeciesExactMatch	CL:0000066	semapv:ManualMappingCuration
+FBbt:00000125	endoderm	semapv:crossSpeciesExactMatch	UBERON:0000925	semapv:ManualMappingCuration
+FBbt:00000126	mesoderm	semapv:crossSpeciesExactMatch	UBERON:0000926	semapv:ManualMappingCuration
+FBbt:00000128	trunk mesoderm	semapv:crossSpeciesExactMatch	UBERON:6000128	semapv:ManualMappingCuration
+FBbt:00000130	visceral mesoderm	semapv:crossSpeciesExactMatch	UBERON:6000130	semapv:ManualMappingCuration
+FBbt:00000136	mesectoderm	semapv:crossSpeciesExactMatch	UBERON:0000927	semapv:ManualMappingCuration
+FBbt:00000137	embryonic tagma	semapv:crossSpeciesExactMatch	UBERON:6000137	semapv:ManualMappingCuration
+FBbt:00000154	embryonic segment	semapv:crossSpeciesExactMatch	UBERON:6000154	semapv:ManualMappingCuration
+FBbt:00000155	embryonic head	semapv:crossSpeciesExactMatch	UBERON:0008816	semapv:ManualMappingCuration
+FBbt:00000157	embryonic head segment	semapv:crossSpeciesExactMatch	UBERON:6000157	semapv:ManualMappingCuration
+FBbt:00000158	embryonic procephalic segment	semapv:crossSpeciesExactMatch	UBERON:6000158	semapv:ManualMappingCuration
+FBbt:00000160	embryonic antennal segment	semapv:crossSpeciesExactMatch	UBERON:6000160	semapv:ManualMappingCuration
+FBbt:00000162	embryonic gnathal segment	semapv:crossSpeciesExactMatch	UBERON:6000162	semapv:ManualMappingCuration
+FBbt:00000165	embryonic labial segment	semapv:crossSpeciesExactMatch	UBERON:6000165	semapv:ManualMappingCuration
+FBbt:00000166	embryonic thorax	semapv:crossSpeciesExactMatch	UBERON:6000166	semapv:ManualMappingCuration
+FBbt:00000167	embryonic thoracic segment	semapv:crossSpeciesExactMatch	UBERON:6000167	semapv:ManualMappingCuration
+FBbt:00000168	embryonic prothoracic segment	semapv:crossSpeciesExactMatch	UBERON:6000168	semapv:ManualMappingCuration
+FBbt:00000169	embryonic mesothoracic segment	semapv:crossSpeciesExactMatch	UBERON:6000169	semapv:ManualMappingCuration
+FBbt:00000170	embryonic metathoracic segment	semapv:crossSpeciesExactMatch	UBERON:6000170	semapv:ManualMappingCuration
+FBbt:00000171	embryonic abdomen	semapv:crossSpeciesExactMatch	UBERON:6000171	semapv:ManualMappingCuration
+FBbt:00000172	embryonic abdominal segment	semapv:crossSpeciesExactMatch	UBERON:6000172	semapv:ManualMappingCuration
+FBbt:00000180	embryonic abdominal segment 8	semapv:crossSpeciesExactMatch	UBERON:6000180	semapv:ManualMappingCuration
+FBbt:00000181	embryonic abdominal segment 9	semapv:crossSpeciesExactMatch	UBERON:6000181	semapv:ManualMappingCuration
+FBbt:00000186	embryonic optic lobe primordium	semapv:crossSpeciesExactMatch	UBERON:6000186	semapv:ManualMappingCuration
+FBbt:00000439	stomodeum	semapv:crossSpeciesExactMatch	UBERON:0000930	semapv:ManualMappingCuration
+FBbt:00001055	presumptive embryonic/larval nervous system	semapv:crossSpeciesExactMatch	UBERON:6001055	semapv:ManualMappingCuration
+FBbt:00001056	presumptive embryonic/larval central nervous system	semapv:crossSpeciesExactMatch	UBERON:6001056	semapv:ManualMappingCuration
+FBbt:00001057	neurogenic region	semapv:crossSpeciesExactMatch	UBERON:0002346	semapv:ManualMappingCuration
+FBbt:00001059	visual primordium	semapv:crossSpeciesExactMatch	UBERON:6001059	semapv:ManualMappingCuration
+FBbt:00001060	embryonic brain	semapv:crossSpeciesExactMatch	UBERON:6001060	semapv:ManualMappingCuration
+FBbt:00001135	proneural cluster	semapv:crossSpeciesExactMatch	UBERON:6001135	semapv:ManualMappingCuration
+FBbt:00001648	embryonic imaginal tissue	semapv:crossSpeciesExactMatch	UBERON:6001648	semapv:ManualMappingCuration
+FBbt:00001649	imaginal disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001649	semapv:ManualMappingCuration
+FBbt:00001650	labial disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001650	semapv:ManualMappingCuration
+FBbt:00001652	eye-antennal disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001652	semapv:ManualMappingCuration
+FBbt:00001653	dorsal thoracic disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001653	semapv:ManualMappingCuration
+FBbt:00001655	dorsal mesothoracic disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001655	semapv:ManualMappingCuration
+FBbt:00001656	dorsal metathoracic disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001656	semapv:ManualMappingCuration
+FBbt:00001657	ventral thoracic disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001657	semapv:ManualMappingCuration
+FBbt:00001658	ventral prothoracic disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001658	semapv:ManualMappingCuration
+FBbt:00001661	genital disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001661	semapv:ManualMappingCuration
+FBbt:00001662	male genital disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001662	semapv:ManualMappingCuration
+FBbt:00001663	female genital disc primordium	semapv:crossSpeciesExactMatch	UBERON:6001663	semapv:ManualMappingCuration
+FBbt:00001664	embryonic/larval circulatory system	semapv:crossSpeciesExactMatch	UBERON:6001664	semapv:ManualMappingCuration
+FBbt:00001666	cardioblast	semapv:crossSpeciesExactMatch	CL:0000465	semapv:ManualMappingCuration
+FBbt:00001668	embryonic/larval lymph gland	semapv:crossSpeciesExactMatch	UBERON:6001668	semapv:ManualMappingCuration
+FBbt:00001685	embryonic/larval plasmatocyte	semapv:crossSpeciesExactMatch	CL:0000394	semapv:ManualMappingCuration
+FBbt:00001687	lamellocyte	semapv:crossSpeciesExactMatch	CL:0000396	semapv:ManualMappingCuration
+FBbt:00001689	procrystal cell	semapv:crossSpeciesExactMatch	CL:0000395	semapv:ManualMappingCuration
+FBbt:00001690	embryonic/larval crystal cell	semapv:crossSpeciesExactMatch	CL:0000715	semapv:ManualMappingCuration
+FBbt:00001691	polygonal cell	semapv:crossSpeciesExactMatch	CL:0000398	semapv:ManualMappingCuration
+FBbt:00001718	retrocerebral complex	semapv:crossSpeciesExactMatch	UBERON:0012325	semapv:ManualMappingCuration
+FBbt:00001722	ring gland	semapv:crossSpeciesExactMatch	UBERON:6001722	semapv:ManualMappingCuration
+FBbt:00001727	larva	semapv:crossSpeciesExactMatch	UBERON:0002548	semapv:ManualMappingCuration
+FBbt:00001728	larval tagma	semapv:crossSpeciesExactMatch	UBERON:6001728	semapv:ManualMappingCuration
+FBbt:00001729	larval segment	semapv:crossSpeciesExactMatch	UBERON:6001729	semapv:ManualMappingCuration
+FBbt:00001730	larval head	semapv:crossSpeciesExactMatch	UBERON:6001730	semapv:ManualMappingCuration
+FBbt:00001731	larval ocular segment	semapv:crossSpeciesExactMatch	UBERON:6001731	semapv:ManualMappingCuration
+FBbt:00001732	larval head segment	semapv:crossSpeciesExactMatch	UBERON:6001732	semapv:ManualMappingCuration
+FBbt:00001733	larval procephalic segment	semapv:crossSpeciesExactMatch	UBERON:6001733	semapv:ManualMappingCuration
+FBbt:00001734	larval labral segment	semapv:crossSpeciesExactMatch	UBERON:6001734	semapv:ManualMappingCuration
+FBbt:00001735	larval antennal segment	semapv:crossSpeciesExactMatch	UBERON:6001735	semapv:ManualMappingCuration
+FBbt:00001737	larval gnathal segment	semapv:crossSpeciesExactMatch	UBERON:6001737	semapv:ManualMappingCuration
+FBbt:00001740	larval labial segment	semapv:crossSpeciesExactMatch	UBERON:6001740	semapv:ManualMappingCuration
+FBbt:00001741	larval thorax	semapv:crossSpeciesExactMatch	UBERON:6001741	semapv:ManualMappingCuration
+FBbt:00001742	larval thoracic segment	semapv:crossSpeciesExactMatch	UBERON:6001742	semapv:ManualMappingCuration
+FBbt:00001743	larval prothoracic segment	semapv:crossSpeciesExactMatch	UBERON:6001743	semapv:ManualMappingCuration
+FBbt:00001744	larval mesothoracic segment	semapv:crossSpeciesExactMatch	UBERON:6001744	semapv:ManualMappingCuration
+FBbt:00001745	larval metathoracic segment	semapv:crossSpeciesExactMatch	UBERON:6001745	semapv:ManualMappingCuration
+FBbt:00001746	larval abdomen	semapv:crossSpeciesExactMatch	UBERON:6001746	semapv:ManualMappingCuration
+FBbt:00001747	larval abdominal segment	semapv:crossSpeciesExactMatch	UBERON:6001747	semapv:ManualMappingCuration
+FBbt:00001755	larval abdominal segment 8	semapv:crossSpeciesExactMatch	UBERON:6001755	semapv:ManualMappingCuration
+FBbt:00001756	larval abdominal segment 9	semapv:crossSpeciesExactMatch	UBERON:6001756	semapv:ManualMappingCuration
+FBbt:00001760	larval imaginal tissue	semapv:crossSpeciesExactMatch	UBERON:6001760	semapv:ManualMappingCuration
+FBbt:00001761	imaginal disc	semapv:crossSpeciesExactMatch	UBERON:0000939	semapv:ManualMappingCuration
+FBbt:00001764	labial disc	semapv:crossSpeciesExactMatch	UBERON:6001764	semapv:ManualMappingCuration
+FBbt:00001765	clypeo-labral disc	semapv:crossSpeciesExactMatch	UBERON:6001765	semapv:ManualMappingCuration
+FBbt:00001766	eye-antennal disc	semapv:crossSpeciesExactMatch	UBERON:6001766	semapv:ManualMappingCuration
+FBbt:00001767	antennal disc	semapv:crossSpeciesExactMatch	UBERON:6001767	semapv:ManualMappingCuration
+FBbt:00001776	dorsal thoracic disc	semapv:crossSpeciesExactMatch	UBERON:6001776	semapv:ManualMappingCuration
+FBbt:00001778	wing disc	semapv:crossSpeciesExactMatch	UBERON:6001778	semapv:ManualMappingCuration
+FBbt:00001779	haltere disc	semapv:crossSpeciesExactMatch	UBERON:6001779	semapv:ManualMappingCuration
+FBbt:00001780	ventral thoracic disc	semapv:crossSpeciesExactMatch	UBERON:6001780	semapv:ManualMappingCuration
+FBbt:00001781	prothoracic leg disc	semapv:crossSpeciesExactMatch	UBERON:6001781	semapv:ManualMappingCuration
+FBbt:00001784	genital disc	semapv:crossSpeciesExactMatch	UBERON:6001784	semapv:ManualMappingCuration
+FBbt:00001785	male genital disc	semapv:crossSpeciesExactMatch	UBERON:6001785	semapv:ManualMappingCuration
+FBbt:00001787	female genital disc	semapv:crossSpeciesExactMatch	UBERON:6001787	semapv:ManualMappingCuration
+FBbt:00001789	histoblast	semapv:crossSpeciesExactMatch	CL:0000373	semapv:ManualMappingCuration
+FBbt:00001789	histoblast	semapv:crossSpeciesExactMatch	UBERON:6001789	semapv:ManualMappingCuration
+FBbt:00001790	histoblast nest	semapv:crossSpeciesExactMatch	UBERON:6001790	semapv:ManualMappingCuration
+FBbt:00001791	dorsal histoblast nest abdominal	semapv:crossSpeciesExactMatch	UBERON:6001791	semapv:ManualMappingCuration
+FBbt:00001792	anterior dorsal histoblast nest abdominal	semapv:crossSpeciesExactMatch	UBERON:6001792	semapv:ManualMappingCuration
+FBbt:00001809	posterior dorsal histoblast nest abdominal	semapv:crossSpeciesExactMatch	UBERON:6001809	semapv:ManualMappingCuration
+FBbt:00001842	embryonic/larval digestive system	semapv:crossSpeciesExactMatch	UBERON:6001842	semapv:ManualMappingCuration
+FBbt:00001845	cephalopharyngeal skeleton	semapv:crossSpeciesExactMatch	UBERON:6001845	semapv:ManualMappingCuration
+FBbt:00001848	epipharyngeal sclerite	semapv:crossSpeciesExactMatch	UBERON:6001848	semapv:ManualMappingCuration
+FBbt:00001911	embryonic/larval nervous system	semapv:crossSpeciesExactMatch	UBERON:6001911	semapv:ManualMappingCuration
+FBbt:00001919	embryonic/larval central nervous system	semapv:crossSpeciesExactMatch	UBERON:6001919	semapv:ManualMappingCuration
+FBbt:00001920	embryonic/larval brain	semapv:crossSpeciesExactMatch	UBERON:6001920	semapv:ManualMappingCuration
+FBbt:00001925	embryonic/larval protocerebrum	semapv:crossSpeciesExactMatch	UBERON:6001925	semapv:ManualMappingCuration
+FBbt:00001956	optic nerve	semapv:crossSpeciesExactMatch	UBERON:0004904	semapv:ManualMappingCuration
+FBbt:00002639	embryonic/larval sense organ	semapv:crossSpeciesExactMatch	UBERON:6002639	semapv:ManualMappingCuration
+FBbt:00002642	embryonic/larval ocular segment sensillum	semapv:crossSpeciesExactMatch	UBERON:6002642	semapv:ManualMappingCuration
+FBbt:00002952	prepupa	semapv:crossSpeciesExactMatch	UBERON:0003142	semapv:ManualMappingCuration
+FBbt:00002953	pupa	semapv:crossSpeciesExactMatch	UBERON:0003143	semapv:ManualMappingCuration
+FBbt:00003004	adult	semapv:crossSpeciesExactMatch	UBERON:0007023	semapv:ManualMappingCuration
+FBbt:00003005	adult tagma	semapv:crossSpeciesExactMatch	UBERON:6003005	semapv:ManualMappingCuration
+FBbt:00003006	adult segment	semapv:crossSpeciesExactMatch	UBERON:6003006	semapv:ManualMappingCuration
+FBbt:00003007	adult head	semapv:crossSpeciesExactMatch	UBERON:6003007	semapv:ManualMappingCuration
+FBbt:00003009	adult head segment	semapv:crossSpeciesExactMatch	UBERON:6003009	semapv:ManualMappingCuration
+FBbt:00003010	adult procephalic segment	semapv:crossSpeciesExactMatch	UBERON:6003010	semapv:ManualMappingCuration
+FBbt:00003011	adult labral segment	semapv:crossSpeciesExactMatch	UBERON:6003011	semapv:ManualMappingCuration
+FBbt:00003012	adult antennal segment	semapv:crossSpeciesExactMatch	UBERON:6003012	semapv:ManualMappingCuration
+FBbt:00003018	adult thorax	semapv:crossSpeciesExactMatch	UBERON:6003018	semapv:ManualMappingCuration
+FBbt:00003019	adult thoracic segment	semapv:crossSpeciesExactMatch	UBERON:6003019	semapv:ManualMappingCuration
+FBbt:00003020	adult prothoracic segment	semapv:crossSpeciesExactMatch	UBERON:6003020	semapv:ManualMappingCuration
+FBbt:00003021	adult mesothoracic segment	semapv:crossSpeciesExactMatch	UBERON:6003021	semapv:ManualMappingCuration
+FBbt:00003023	adult abdomen	semapv:crossSpeciesExactMatch	UBERON:6003023	semapv:ManualMappingCuration
+FBbt:00003024	adult abdominal segment	semapv:crossSpeciesExactMatch	UBERON:6003024	semapv:ManualMappingCuration
+FBbt:00003039	adult dorsal trunk	semapv:crossSpeciesExactMatch	UBERON:6003039	semapv:ManualMappingCuration
+FBbt:00003125	alimentary canal	semapv:crossSpeciesExactMatch	UBERON:0001555	semapv:ManualMappingCuration
+FBbt:00003126	adult mouth	semapv:crossSpeciesExactMatch	UBERON:0000165	semapv:ManualMappingCuration
+FBbt:00003154	adult heart	semapv:crossSpeciesExactMatch	UBERON:0015230	semapv:ManualMappingCuration
+FBbt:00003219	adepithelial cell	semapv:crossSpeciesExactMatch	CL:0000462	semapv:ManualMappingCuration
+FBbt:00003259	adult somatic muscle	semapv:crossSpeciesExactMatch	UBERON:6003259	semapv:ManualMappingCuration
+FBbt:00003559	adult nervous system	semapv:crossSpeciesExactMatch	UBERON:6003559	semapv:ManualMappingCuration
+FBbt:00003623	adult central nervous system	semapv:crossSpeciesExactMatch	UBERON:6003623	semapv:ManualMappingCuration
+FBbt:00003624	adult brain	semapv:crossSpeciesExactMatch	UBERON:6003624	semapv:ManualMappingCuration
+FBbt:00003626	supraesophageal ganglion	semapv:crossSpeciesExactMatch	UBERON:6003626	semapv:ManualMappingCuration
+FBbt:00003627	protocerebrum	semapv:crossSpeciesExactMatch	UBERON:6003627	semapv:ManualMappingCuration
+FBbt:00003632	adult central complex	semapv:crossSpeciesExactMatch	UBERON:6003632	semapv:ManualMappingCuration
+FBbt:00003701	adult optic lobe	semapv:crossSpeciesExactMatch	UBERON:0006795	semapv:ManualMappingCuration
+FBbt:00004101	peptidergic neuron	semapv:crossSpeciesExactMatch	CL:0000110	semapv:ManualMappingCuration
+FBbt:00004114	head sensillum	semapv:crossSpeciesExactMatch	UBERON:0000963	semapv:ManualMappingCuration
+FBbt:00004193	cone cell	semapv:crossSpeciesExactMatch	CL:0000718	semapv:ManualMappingCuration
+FBbt:00004199	lens	semapv:crossSpeciesExactMatch	UBERON:0000207	semapv:ManualMappingCuration
+FBbt:00004200	retina	semapv:crossSpeciesExactMatch	UBERON:0005388	semapv:ManualMappingCuration
+FBbt:00004203	adult clypeo-labral anlage	semapv:crossSpeciesExactMatch	UBERON:6004203	semapv:ManualMappingCuration
+FBbt:00004208	developing embryonic structure	semapv:crossSpeciesExactMatch	UBERON:0002050	semapv:ManualMappingCuration
+FBbt:00004211	photoreceptor cell	semapv:crossSpeciesExactMatch	CL:2000019	semapv:ManualMappingCuration
+FBbt:00004230	pigment cell	semapv:crossSpeciesExactMatch	CL:0001658	semapv:ManualMappingCuration
+FBbt:00004296	sex comb	semapv:crossSpeciesExactMatch	UBERON:6004296	semapv:ManualMappingCuration
+FBbt:00004340	wing hair	semapv:crossSpeciesExactMatch	UBERON:6004340	semapv:ManualMappingCuration
+FBbt:00004475	sclerite	semapv:crossSpeciesExactMatch	UBERON:6004475	semapv:ManualMappingCuration
+FBbt:00004476	tergite	semapv:crossSpeciesExactMatch	UBERON:6004476	semapv:ManualMappingCuration
+FBbt:00004477	sternite	semapv:crossSpeciesExactMatch	UBERON:6004477	semapv:ManualMappingCuration
+FBbt:00004481	adult external head	semapv:crossSpeciesExactMatch	UBERON:6004481	semapv:ManualMappingCuration
+FBbt:00004492	occiput	semapv:crossSpeciesExactMatch	UBERON:0003155	semapv:ManualMappingCuration
+FBbt:00004505	ocellus	semapv:crossSpeciesExactMatch	UBERON:0003161	semapv:ManualMappingCuration
+FBbt:00004506	lateral ocellus	semapv:crossSpeciesExactMatch	UBERON:0003162	semapv:ManualMappingCuration
+FBbt:00004507	medial ocellus	semapv:crossSpeciesExactMatch	UBERON:0003211	semapv:ManualMappingCuration
+FBbt:00004508	eye	semapv:crossSpeciesExactMatch	UBERON:0000018	semapv:ManualMappingCuration
+FBbt:00004510	ommatidium	semapv:crossSpeciesExactMatch	UBERON:0000971	semapv:ManualMappingCuration
+FBbt:00004511	antenna	semapv:crossSpeciesExactMatch	UBERON:0000972	semapv:ManualMappingCuration
+FBbt:00004519	arista	semapv:crossSpeciesExactMatch	UBERON:6004519	semapv:ManualMappingCuration
+FBbt:00004520	mouthpart	semapv:crossSpeciesExactMatch	UBERON:6004520	semapv:ManualMappingCuration
+FBbt:00004521	clypeus	semapv:crossSpeciesExactMatch	UBERON:6004521	semapv:ManualMappingCuration
+FBbt:00004522	labrum	semapv:crossSpeciesExactMatch	UBERON:0005905	semapv:ManualMappingCuration
+FBbt:00004535	proboscis	semapv:crossSpeciesExactMatch	UBERON:6004535	semapv:ManualMappingCuration
+FBbt:00004540	rostrum	semapv:crossSpeciesExactMatch	UBERON:6004540	semapv:ManualMappingCuration
+FBbt:00004551	adult external thorax	semapv:crossSpeciesExactMatch	UBERON:6004551	semapv:ManualMappingCuration
+FBbt:00004552	tergum	semapv:crossSpeciesExactMatch	UBERON:6004552	semapv:ManualMappingCuration
+FBbt:00004557	sternum	semapv:crossSpeciesExactMatch	UBERON:0003130	semapv:ManualMappingCuration
+FBbt:00004578	adult external mesothorax	semapv:crossSpeciesExactMatch	UBERON:6004578	semapv:ManualMappingCuration
+FBbt:00004579	dorsal mesothorax	semapv:crossSpeciesExactMatch	UBERON:6004579	semapv:ManualMappingCuration
+FBbt:00004580	mesothoracic tergum	semapv:crossSpeciesExactMatch	UBERON:6004580	semapv:ManualMappingCuration
+FBbt:00004640	leg	semapv:crossSpeciesExactMatch	UBERON:0005895	semapv:ManualMappingCuration
+FBbt:00004642	tibia	semapv:crossSpeciesExactMatch	UBERON:0003131	semapv:ManualMappingCuration
+FBbt:00004646	tarsal segment	semapv:crossSpeciesExactMatch	UBERON:6004646	semapv:ManualMappingCuration
+FBbt:00004648	metatarsus	semapv:crossSpeciesExactMatch	UBERON:6004648	semapv:ManualMappingCuration
+FBbt:00004663	prothoracic leg	semapv:crossSpeciesExactMatch	UBERON:6004663	semapv:ManualMappingCuration
+FBbt:00004668	prothoracic tarsal segment	semapv:crossSpeciesExactMatch	UBERON:6004668	semapv:ManualMappingCuration
+FBbt:00004670	prothoracic metatarsus	semapv:crossSpeciesExactMatch	UBERON:6004670	semapv:ManualMappingCuration
+FBbt:00004729	wing	semapv:crossSpeciesExactMatch	UBERON:0000984	semapv:ManualMappingCuration
+FBbt:00004751	wing vein	semapv:crossSpeciesExactMatch	UBERON:0003194	semapv:ManualMappingCuration
+FBbt:00004783	haltere	semapv:crossSpeciesExactMatch	UBERON:0000987	semapv:ManualMappingCuration
+FBbt:00004788	adult external abdomen	semapv:crossSpeciesExactMatch	UBERON:6004788	semapv:ManualMappingCuration
+FBbt:00004823	analia	semapv:crossSpeciesExactMatch	UBERON:6004823	semapv:ManualMappingCuration
+FBbt:00004824	female analia	semapv:crossSpeciesExactMatch	UBERON:6004824	semapv:ManualMappingCuration
+FBbt:00004825	male analia	semapv:crossSpeciesExactMatch	UBERON:6004825	semapv:ManualMappingCuration
+FBbt:00004850	phallus	semapv:crossSpeciesExactMatch	UBERON:0008811	semapv:ManualMappingCuration
+FBbt:00004856	organ system	semapv:crossSpeciesExactMatch	UBERON:0000467	semapv:ManualMappingCuration
+FBbt:00004857	reproductive system	semapv:crossSpeciesExactMatch	UBERON:0000990	semapv:ManualMappingCuration
+FBbt:00004858	gonad	semapv:crossSpeciesExactMatch	UBERON:0000991	semapv:ManualMappingCuration
+FBbt:00004861	germline stem cell	semapv:crossSpeciesExactMatch	CL:0000086	semapv:ManualMappingCuration
+FBbt:00004864	female reproductive system	semapv:crossSpeciesExactMatch	UBERON:0000474	semapv:ManualMappingCuration
+FBbt:00004865	ovary	semapv:crossSpeciesExactMatch	UBERON:0000992	semapv:ManualMappingCuration
+FBbt:00004873	female germline stem cell	semapv:crossSpeciesExactMatch	CL:0000022	semapv:ManualMappingCuration
+FBbt:00004878	nurse cell	semapv:crossSpeciesExactMatch	CL:0000026	semapv:ManualMappingCuration
+FBbt:00004886	oocyte	semapv:crossSpeciesExactMatch	CL:0000023	semapv:ManualMappingCuration
+FBbt:00004894	egg chamber	semapv:crossSpeciesExactMatch	UBERON:0003199	semapv:ManualMappingCuration
+FBbt:00004903	follicle stem cell	semapv:crossSpeciesExactMatch	CL:0000441	semapv:ManualMappingCuration
+FBbt:00004904	follicle cell	semapv:crossSpeciesExactMatch	CL:0000477	semapv:ManualMappingCuration
+FBbt:00004905	border follicle cell	semapv:crossSpeciesExactMatch	CL:0000579	semapv:ManualMappingCuration
+FBbt:00004906	centripetal follicle cell	semapv:crossSpeciesExactMatch	CL:0000671	semapv:ManualMappingCuration
+FBbt:00004910	stalk follicle cell	semapv:crossSpeciesExactMatch	CL:0000674	semapv:ManualMappingCuration
+FBbt:00004921	spermathecum	semapv:crossSpeciesExactMatch	UBERON:0000994	semapv:ManualMappingCuration
+FBbt:00004924	uterus	semapv:crossSpeciesCloseMatch	UBERON:0006834	semapv:ManualMappingCuration
+FBbt:00004927	male reproductive system	semapv:crossSpeciesExactMatch	UBERON:0000079	semapv:ManualMappingCuration
+FBbt:00004928	testis	semapv:crossSpeciesExactMatch	UBERON:0000473	semapv:ManualMappingCuration
+FBbt:00004929	male germline stem cell	semapv:crossSpeciesExactMatch	CL:0000087	semapv:ManualMappingCuration
+FBbt:00004934	primary gonial cell	semapv:crossSpeciesExactMatch	CL:0000020	semapv:ManualMappingCuration
+FBbt:00004935	spermatogonium	semapv:crossSpeciesExactMatch	CL:0000020	semapv:ManualMappingCuration
+FBbt:00004936	spermatocyte	semapv:crossSpeciesExactMatch	CL:0000017	semapv:ManualMappingCuration
+FBbt:00004941	secondary spermatocyte	semapv:crossSpeciesExactMatch	CL:0000657	semapv:ManualMappingCuration
+FBbt:00004942	spermatid	semapv:crossSpeciesExactMatch	CL:0000018	semapv:ManualMappingCuration
+FBbt:00004954	spermatozoon	semapv:crossSpeciesExactMatch	CL:0000019	semapv:ManualMappingCuration
+FBbt:00004958	seminal vesicle	semapv:crossSpeciesExactMatch	UBERON:0006868	semapv:ManualMappingCuration
+FBbt:00004969	integumentary system	semapv:crossSpeciesExactMatch	UBERON:0002416	semapv:ManualMappingCuration
+FBbt:00004970	cuticle	semapv:crossSpeciesExactMatch	UBERON:0001001	semapv:ManualMappingCuration
+FBbt:00004973	exocuticle	semapv:crossSpeciesExactMatch	UBERON:0003201	semapv:ManualMappingCuration
+FBbt:00004974	endocuticle	semapv:crossSpeciesExactMatch	UBERON:0003202	semapv:ManualMappingCuration
+FBbt:00004979	trichome	semapv:crossSpeciesExactMatch	UBERON:6004979	semapv:ManualMappingCuration
+FBbt:00004983	embryonic/larval cuticle	semapv:crossSpeciesExactMatch	UBERON:6004983	semapv:ManualMappingCuration
+FBbt:00004986	third instar larval cuticle	semapv:crossSpeciesExactMatch	UBERON:6004986	semapv:ManualMappingCuration
+FBbt:00004987	puparium cuticle	semapv:crossSpeciesExactMatch	UBERON:0018656	semapv:ManualMappingCuration
+FBbt:00004993	epidermis	semapv:crossSpeciesExactMatch	UBERON:0007376	semapv:ManualMappingCuration
+FBbt:00004994	epidermoblast	semapv:crossSpeciesExactMatch	CL:0000464	semapv:ManualMappingCuration
+FBbt:00004995	oenocyte	semapv:crossSpeciesExactMatch	CL:0000487	semapv:ManualMappingCuration
+FBbt:00005023	imaginal precursor	semapv:crossSpeciesExactMatch	UBERON:6005023	semapv:ManualMappingCuration
+FBbt:00005024	tracheal system	semapv:crossSpeciesExactMatch	UBERON:0005155	semapv:ManualMappingCuration
+FBbt:00005036	tracheal pit	semapv:crossSpeciesExactMatch	UBERON:6005036	semapv:ManualMappingCuration
+FBbt:00005037	tracheal primordium	semapv:crossSpeciesExactMatch	UBERON:6005037	semapv:ManualMappingCuration
+FBbt:00005038	tracheocyte	semapv:crossSpeciesExactMatch	CL:0000307	semapv:ManualMappingCuration
+FBbt:00005043	trachea	semapv:crossSpeciesExactMatch	UBERON:6005043	semapv:ManualMappingCuration
+FBbt:00005054	spiracle	semapv:crossSpeciesExactMatch	UBERON:6005054	semapv:ManualMappingCuration
+FBbt:00005055	digestive system	semapv:crossSpeciesExactMatch	UBERON:0001007	semapv:ManualMappingCuration
+FBbt:00005056	excretory system	semapv:crossSpeciesExactMatch	UBERON:0001008	semapv:ManualMappingCuration
+FBbt:00005057	circulatory system	semapv:crossSpeciesExactMatch	UBERON:0009054	semapv:ManualMappingCuration
+FBbt:00005058	pericardial cell	semapv:crossSpeciesExactMatch	CL:0000474	semapv:ManualMappingCuration
+FBbt:00005059	garland cell	semapv:crossSpeciesExactMatch	CL:0000486	semapv:ManualMappingCuration
+FBbt:00005060	hemocoel	semapv:crossSpeciesExactMatch	UBERON:0002323	semapv:ManualMappingCuration
+FBbt:00005061	hemolymph	semapv:crossSpeciesExactMatch	UBERON:0001011	semapv:ManualMappingCuration
+FBbt:00005062	prohemocyte	semapv:crossSpeciesExactMatch	CL:0000385	semapv:ManualMappingCuration
+FBbt:00005063	hemocyte	semapv:crossSpeciesExactMatch	CL:0000387	semapv:ManualMappingCuration
+FBbt:00005066	fat body	semapv:crossSpeciesExactMatch	UBERON:0003917	semapv:ManualMappingCuration
+FBbt:00005068	endocrine system	semapv:crossSpeciesExactMatch	UBERON:0000949	semapv:ManualMappingCuration
+FBbt:00005070	visceral muscle cell	semapv:crossSpeciesExactMatch	CL:0008007	semapv:ManualMappingCuration
+FBbt:00005073	somatic muscle cell	semapv:crossSpeciesExactMatch	CL:0008004	semapv:ManualMappingCuration
+FBbt:00005074	muscle cell	semapv:crossSpeciesExactMatch	CL:0000187	semapv:ManualMappingCuration
+FBbt:00005083	myoblast	semapv:crossSpeciesExactMatch	CL:0000056	semapv:ManualMappingCuration
+FBbt:00005093	nervous system	semapv:crossSpeciesExactMatch	UBERON:0001016	semapv:ManualMappingCuration
+FBbt:00005094	central nervous system	semapv:crossSpeciesExactMatch	UBERON:0001017	semapv:ManualMappingCuration
+FBbt:00005095	brain	semapv:crossSpeciesExactMatch	UBERON:0000955	semapv:ManualMappingCuration
+FBbt:00005096	stomatogastric nervous system	semapv:crossSpeciesExactMatch	UBERON:6005096	semapv:ManualMappingCuration
+FBbt:00005097	ventral nerve cord	semapv:crossSpeciesExactMatch	UBERON:0000934	semapv:ManualMappingCuration
+FBbt:00005098	peripheral nervous system	semapv:crossSpeciesExactMatch	UBERON:0000010	semapv:ManualMappingCuration
+FBbt:00005099	neuron projection bundle	semapv:crossSpeciesExactMatch	UBERON:0000122	semapv:ManualMappingCuration
+FBbt:00005100	tract	semapv:crossSpeciesExactMatch	UBERON:0001018	semapv:ManualMappingCuration
+FBbt:00005105	nerve	semapv:crossSpeciesExactMatch	UBERON:0001021	semapv:ManualMappingCuration
+FBbt:00005106	neuron	semapv:crossSpeciesExactMatch	CL:0000540	semapv:ManualMappingCuration
+FBbt:00005123	motor neuron	semapv:crossSpeciesExactMatch	CL:0000100	semapv:ManualMappingCuration
+FBbt:00005124	sensory neuron	semapv:crossSpeciesExactMatch	CL:0000101	semapv:ManualMappingCuration
+FBbt:00005125	interneuron	semapv:crossSpeciesExactMatch	CL:0000099	semapv:ManualMappingCuration
+FBbt:00005128	pioneer neuron	semapv:crossSpeciesExactMatch	CL:0000116	semapv:ManualMappingCuration
+FBbt:00005130	neurosecretory neuron	semapv:crossSpeciesExactMatch	CL:0000381	semapv:ManualMappingCuration
+FBbt:00005131	dopaminergic neuron	semapv:crossSpeciesExactMatch	CL:0000700	semapv:ManualMappingCuration
+FBbt:00005133	serotonergic neuron	semapv:crossSpeciesExactMatch	CL:0000850	semapv:ManualMappingCuration
+FBbt:00005136	sensory nerve	semapv:crossSpeciesExactMatch	UBERON:0001027	semapv:ManualMappingCuration
+FBbt:00005139	neuropil	semapv:crossSpeciesExactMatch	UBERON:0002606	semapv:ManualMappingCuration
+FBbt:00005144	glial cell	semapv:crossSpeciesExactMatch	CL:0000125	semapv:ManualMappingCuration
+FBbt:00005145	glioblast	semapv:crossSpeciesExactMatch	CL:0000340	semapv:ManualMappingCuration
+FBbt:00005146	neuroblast	semapv:crossSpeciesExactMatch	CL:0000338	semapv:ManualMappingCuration
+FBbt:00005147	neuroglioblast	semapv:crossSpeciesExactMatch	CL:0000468	semapv:ManualMappingCuration
+FBbt:00005148	neuroepidermoblast	semapv:crossSpeciesExactMatch	CL:0000405	semapv:ManualMappingCuration
+FBbt:00005149	ganglion mother cell	semapv:crossSpeciesExactMatch	CL:0000469	semapv:ManualMappingCuration
+FBbt:00005155	sense organ	semapv:crossSpeciesExactMatch	UBERON:0000020	semapv:ManualMappingCuration
+FBbt:00005157	chemosensory sensory organ	semapv:crossSpeciesExactMatch	UBERON:0000005	semapv:ManualMappingCuration
+FBbt:00005158	olfactory sensory organ	semapv:crossSpeciesExactMatch	UBERON:0002268	semapv:ManualMappingCuration
+FBbt:00005159	gustatory sensory organ	semapv:crossSpeciesExactMatch	UBERON:0003212	semapv:ManualMappingCuration
+FBbt:00005162	photoreceptor	semapv:crossSpeciesExactMatch	UBERON:0000970	semapv:ManualMappingCuration
+FBbt:00005168	external sensory organ	semapv:crossSpeciesExactMatch	UBERON:6005168	semapv:ManualMappingCuration
+FBbt:00005169	trichogen cell	semapv:crossSpeciesExactMatch	CL:0000374	semapv:ManualMappingCuration
+FBbt:00005171	tormogen cell	semapv:crossSpeciesExactMatch	CL:0000372	semapv:ManualMappingCuration
+FBbt:00005177	chaeta	semapv:crossSpeciesExactMatch	UBERON:6005177	semapv:ManualMappingCuration
+FBbt:00005215	chordotonal organ	semapv:crossSpeciesExactMatch	UBERON:0001038	semapv:ManualMappingCuration
+FBbt:00005219	scolopale cell	semapv:crossSpeciesExactMatch	CL:0000382	semapv:ManualMappingCuration
+FBbt:00005221	scolopidial ligament cell	semapv:crossSpeciesExactMatch	CL:0000407	semapv:ManualMappingCuration
+FBbt:00005317	gastrula embryo	semapv:crossSpeciesExactMatch	UBERON:0004734	semapv:ManualMappingCuration
+FBbt:00005333	late embryo	semapv:crossSpeciesExactMatch	UBERON:0000323	semapv:ManualMappingCuration
+FBbt:00005338	second instar larva	semapv:crossSpeciesExactMatch	UBERON:0018382	semapv:ManualMappingCuration
+FBbt:00005378	wing margin	semapv:crossSpeciesExactMatch	UBERON:6005378	semapv:ManualMappingCuration
+FBbt:00005379	foregut	semapv:crossSpeciesExactMatch	UBERON:0001041	semapv:ManualMappingCuration
+FBbt:00005380	pharynx	semapv:crossSpeciesExactMatch	UBERON:0006562	semapv:ManualMappingCuration
+FBbt:00005382	salivary gland	semapv:crossSpeciesExactMatch	UBERON:0001044	semapv:ManualMappingCuration
+FBbt:00005383	midgut	semapv:crossSpeciesExactMatch	UBERON:0001045	semapv:ManualMappingCuration
+FBbt:00005384	hindgut	semapv:crossSpeciesExactMatch	UBERON:0001046	semapv:ManualMappingCuration
+FBbt:00005386	glomerulus	semapv:crossSpeciesExactMatch	UBERON:0001047	semapv:ManualMappingCuration
+FBbt:00005393	embryonic/larval integumentary system	semapv:crossSpeciesExactMatch	UBERON:6005393	semapv:ManualMappingCuration
+FBbt:00005396	adult integumentary system	semapv:crossSpeciesExactMatch	UBERON:6005396	semapv:ManualMappingCuration
+FBbt:00005412	gamete	semapv:crossSpeciesExactMatch	CL:0000300	semapv:ManualMappingCuration
+FBbt:00005413	anlage in statu nascendi	semapv:crossSpeciesExactMatch	UBERON:6005413	semapv:ManualMappingCuration
+FBbt:00005426	anlage	semapv:crossSpeciesExactMatch	UBERON:0007688	semapv:ManualMappingCuration
+FBbt:00005427	ectoderm anlage	semapv:crossSpeciesExactMatch	UBERON:6005427	semapv:ManualMappingCuration
+FBbt:00005428	dorsal ectoderm anlage	semapv:crossSpeciesExactMatch	UBERON:6005428	semapv:ManualMappingCuration
+FBbt:00005434	visual anlage	semapv:crossSpeciesExactMatch	UBERON:6005434	semapv:ManualMappingCuration
+FBbt:00005436	trunk mesoderm anlage	semapv:crossSpeciesExactMatch	UBERON:6005436	semapv:ManualMappingCuration
+FBbt:00005439	clypeo-labral anlage	semapv:crossSpeciesExactMatch	UBERON:6005439	semapv:ManualMappingCuration
+FBbt:00005461	circulatory system primordium	semapv:crossSpeciesExactMatch	UBERON:6005461	semapv:ManualMappingCuration
+FBbt:00005467	lymph gland primordium	semapv:crossSpeciesExactMatch	UBERON:6005467	semapv:ManualMappingCuration
+FBbt:00005495	primordium	semapv:crossSpeciesExactMatch	UBERON:0001048	semapv:ManualMappingCuration
+FBbt:00005514	clypeo-labral disc primordium	semapv:crossSpeciesExactMatch	UBERON:6005514	semapv:ManualMappingCuration
+FBbt:00005526	dorsal epidermis primordium	semapv:crossSpeciesExactMatch	UBERON:6005526	semapv:ManualMappingCuration
+FBbt:00005533	ventral epidermis primordium	semapv:crossSpeciesExactMatch	UBERON:6005533	semapv:ManualMappingCuration
+FBbt:00005538	clypeo-labral primordium	semapv:crossSpeciesExactMatch	UBERON:6005538	semapv:ManualMappingCuration
+FBbt:00005558	ventral ectoderm	semapv:crossSpeciesExactMatch	UBERON:6005558	semapv:ManualMappingCuration
+FBbt:00005569	presumptive embryonic/larval tracheal system	semapv:crossSpeciesExactMatch	UBERON:6005569	semapv:ManualMappingCuration
+FBbt:00005756	rectum	semapv:crossSpeciesExactMatch	UBERON:0006866	semapv:ManualMappingCuration
+FBbt:00005757	neurohemal organ	semapv:crossSpeciesExactMatch	UBERON:0001053	semapv:ManualMappingCuration
+FBbt:00005786	Malpighian tubule	semapv:crossSpeciesExactMatch	UBERON:0001054	semapv:ManualMappingCuration
+FBbt:00005797	Malpighian tubule Type II cell	semapv:crossSpeciesExactMatch	CL:1000155	semapv:ManualMappingCuration
+FBbt:00005799	corpus cardiacum	semapv:crossSpeciesExactMatch	UBERON:0001056	semapv:ManualMappingCuration
+FBbt:00005800	corpus allatum	semapv:crossSpeciesExactMatch	UBERON:0001057	semapv:ManualMappingCuration
+FBbt:00005801	mushroom body	semapv:crossSpeciesExactMatch	UBERON:0001058	semapv:ManualMappingCuration
+FBbt:00005802	pars intercerebralis	semapv:crossSpeciesExactMatch	UBERON:0001059	semapv:ManualMappingCuration
+FBbt:00005805	Bolwig organ	semapv:crossSpeciesExactMatch	UBERON:6005805	semapv:ManualMappingCuration
+FBbt:00005811	articulation	semapv:crossSpeciesExactMatch	UBERON:0004905	semapv:ManualMappingCuration
+FBbt:00005812	myotube	semapv:crossSpeciesExactMatch	CL:0002372	semapv:ManualMappingCuration
+FBbt:00005830	Bolwig organ primordium	semapv:crossSpeciesExactMatch	UBERON:6005830	semapv:ManualMappingCuration
+FBbt:00005831	dorsal imaginal tissue	semapv:crossSpeciesExactMatch	UBERON:6005831	semapv:ManualMappingCuration
+FBbt:00005835	extraembryonic structure	semapv:crossSpeciesExactMatch	UBERON:0000478	semapv:ManualMappingCuration
+FBbt:00005913	arista lateral	semapv:crossSpeciesExactMatch	UBERON:6005913	semapv:ManualMappingCuration
+FBbt:00005917	lymph gland derived hemocyte	semapv:crossSpeciesExactMatch	CL:0000735	semapv:ManualMappingCuration
+FBbt:00006011	pharate adult	semapv:crossSpeciesExactMatch	UBERON:6006011	semapv:ManualMappingCuration
+FBbt:00006032	mesothoracic tergum primordium	semapv:crossSpeciesExactMatch	UBERON:6006032	semapv:ManualMappingCuration
+FBbt:00007000	appendage	semapv:crossSpeciesExactMatch	UBERON:0000026	semapv:ManualMappingCuration
+FBbt:00007001	anatomical structure	semapv:crossSpeciesExactMatch	UBERON:0000061	semapv:ManualMappingCuration
+FBbt:00007002	cell	semapv:crossSpeciesExactMatch	CL:0000000	semapv:ManualMappingCuration
+FBbt:00007003	portion of tissue	semapv:crossSpeciesExactMatch	UBERON:0000479	semapv:ManualMappingCuration
+FBbt:00007004	male organism	semapv:crossSpeciesExactMatch	UBERON:0003101	semapv:ManualMappingCuration
+FBbt:00007005	epithelium	semapv:crossSpeciesExactMatch	UBERON:0000483	semapv:ManualMappingCuration
+FBbt:00007006	developing material anatomical entity	semapv:crossSpeciesExactMatch	UBERON:0005423	semapv:ManualMappingCuration
+FBbt:00007009	organism subdivision	semapv:crossSpeciesExactMatch	UBERON:0000475	semapv:ManualMappingCuration
+FBbt:00007010	multi-tissue structure	semapv:crossSpeciesExactMatch	UBERON:0000481	semapv:ManualMappingCuration
+FBbt:00007011	female organism	semapv:crossSpeciesExactMatch	UBERON:0003100	semapv:ManualMappingCuration
+FBbt:00007013	acellular anatomical structure	semapv:crossSpeciesExactMatch	UBERON:0000476	semapv:ManualMappingCuration
+FBbt:00007015	immaterial anatomical entity	semapv:crossSpeciesExactMatch	UBERON:0000466	semapv:ManualMappingCuration
+FBbt:00007016	material anatomical entity	semapv:crossSpeciesExactMatch	UBERON:0000465	semapv:ManualMappingCuration
+FBbt:00007017	anatomical space	semapv:crossSpeciesExactMatch	UBERON:0000464	semapv:ManualMappingCuration
+FBbt:00007018	appendage segment	semapv:crossSpeciesExactMatch	UBERON:0010758	semapv:ManualMappingCuration
+FBbt:00007019	portion of organism substance	semapv:crossSpeciesExactMatch	UBERON:0000463	semapv:ManualMappingCuration
+FBbt:00007020	metatarsus of male prothoracic leg	semapv:crossSpeciesExactMatch	UBERON:6007020	semapv:ManualMappingCuration
+FBbt:00007027	cuboidal/columnar epithelium	semapv:crossSpeciesExactMatch	UBERON:0000485	semapv:ManualMappingCuration
+FBbt:00007045	trunk ectoderm	semapv:crossSpeciesExactMatch	UBERON:6007045	semapv:ManualMappingCuration
+FBbt:00007046	dorsal ectoderm derivative	semapv:crossSpeciesExactMatch	UBERON:6007046	semapv:ManualMappingCuration
+FBbt:00007060	multi-cell-component structure	semapv:crossSpeciesExactMatch	UBERON:0005162	semapv:ManualMappingCuration
+FBbt:00007070	embryonic/larval posterior inferior protocerebrum	semapv:crossSpeciesExactMatch	UBERON:6007070	semapv:ManualMappingCuration
+FBbt:00007091	subperineurial glial sheath	semapv:crossSpeciesCloseMatch	UBERON:0000202	semapv:ManualMappingCuration
+FBbt:00007116	presumptive embryonic/larval system	semapv:crossSpeciesExactMatch	UBERON:6007116	semapv:ManualMappingCuration
+FBbt:00007145	adult protocerebrum	semapv:crossSpeciesExactMatch	UBERON:6007145	semapv:ManualMappingCuration
+FBbt:00007149	segment of antenna	semapv:crossSpeciesExactMatch	UBERON:6007149	semapv:ManualMappingCuration
+FBbt:00007150	segment of leg	semapv:crossSpeciesExactMatch	UBERON:6007150	semapv:ManualMappingCuration
+FBbt:00007152	sensillum	semapv:crossSpeciesExactMatch	UBERON:0002536	semapv:ManualMappingCuration
+FBbt:00007173	cholinergic neuron	semapv:crossSpeciesExactMatch	CL:0000108	semapv:ManualMappingCuration
+FBbt:00007228	GABAergic neuron	semapv:crossSpeciesExactMatch	CL:0000617	semapv:ManualMappingCuration
+FBbt:00007229	cell cluster organ	semapv:crossSpeciesExactMatch	UBERON:0010001	semapv:ManualMappingCuration
+FBbt:00007230	compound cell cluster organ	semapv:crossSpeciesExactMatch	UBERON:0014732	semapv:ManualMappingCuration
+FBbt:00007231	external sensillum	semapv:crossSpeciesExactMatch	UBERON:6007231	semapv:ManualMappingCuration
+FBbt:00007232	eo-type sensillum	semapv:crossSpeciesExactMatch	UBERON:6007232	semapv:ManualMappingCuration
+FBbt:00007233	internal sensillum	semapv:crossSpeciesExactMatch	UBERON:6007233	semapv:ManualMappingCuration
+FBbt:00007240	embryonic/larval sensillum	semapv:crossSpeciesExactMatch	UBERON:6007240	semapv:ManualMappingCuration
+FBbt:00007242	embryonic/larval head sensillum	semapv:crossSpeciesExactMatch	UBERON:6007242	semapv:ManualMappingCuration
+FBbt:00007245	cuticular specialization	semapv:crossSpeciesExactMatch	UBERON:6007245	semapv:ManualMappingCuration
+FBbt:00007248	chorionic specialization	semapv:crossSpeciesExactMatch	UBERON:6007248	semapv:ManualMappingCuration
+FBbt:00007276	anatomical group	semapv:crossSpeciesExactMatch	UBERON:0034923	semapv:ManualMappingCuration
+FBbt:00007277	anatomical cluster	semapv:crossSpeciesExactMatch	UBERON:0000477	semapv:ManualMappingCuration
+FBbt:00007278	non-connected functional system	semapv:crossSpeciesExactMatch	UBERON:0015203	semapv:ManualMappingCuration
+FBbt:00007280	embryonic/larval head sense organ	semapv:crossSpeciesExactMatch	UBERON:6007280	semapv:ManualMappingCuration
+FBbt:00007284	region of integument	semapv:crossSpeciesExactMatch	UBERON:6007284	semapv:ManualMappingCuration
+FBbt:00007285	segmental subdivision of integument	semapv:crossSpeciesExactMatch	UBERON:6007285	semapv:ManualMappingCuration
+FBbt:00007288	integumentary specialization	semapv:crossSpeciesExactMatch	UBERON:6007288	semapv:ManualMappingCuration
+FBbt:00007289	tagmatic subdivision of integument	semapv:crossSpeciesExactMatch	UBERON:6007289	semapv:ManualMappingCuration
+FBbt:00007325	epidermal cell	semapv:crossSpeciesExactMatch	CL:0000463	semapv:ManualMappingCuration
+FBbt:00007330	organ system subdivision	semapv:crossSpeciesExactMatch	UBERON:0011216	semapv:ManualMappingCuration
+FBbt:00007331	segmental subdivision of organ system	semapv:crossSpeciesExactMatch	UBERON:6007331	semapv:ManualMappingCuration
+FBbt:00007367	histaminergic neuron	semapv:crossSpeciesExactMatch	CL:0011110	semapv:ManualMappingCuration
+FBbt:00007373	internal sense organ	semapv:crossSpeciesExactMatch	UBERON:6007373	semapv:ManualMappingCuration
+FBbt:00007410	tracheal lumen	semapv:crossSpeciesExactMatch	UBERON:0006832	semapv:ManualMappingCuration
+FBbt:00007424	epithelial furrow	semapv:crossSpeciesExactMatch	UBERON:6007424	semapv:ManualMappingCuration
+FBbt:00007474	epithelial tube	semapv:crossSpeciesExactMatch	UBERON:0003914	semapv:ManualMappingCuration
+FBbt:00007692	sensory system	semapv:crossSpeciesExactMatch	UBERON:0001032	semapv:ManualMappingCuration
+FBbt:00016022	abdominal histoblast primordium	semapv:crossSpeciesExactMatch	UBERON:6016022	semapv:ManualMappingCuration
+FBbt:00017021	abdominal histoblast anlage	semapv:crossSpeciesExactMatch	UBERON:6017021	semapv:ManualMappingCuration
+FBbt:00040003	non-connected developing system	semapv:crossSpeciesExactMatch	UBERON:6040003	semapv:ManualMappingCuration
+FBbt:00040005	synaptic neuropil	semapv:crossSpeciesExactMatch	UBERON:6040005	semapv:ManualMappingCuration
+FBbt:00040007	synaptic neuropil domain	semapv:crossSpeciesExactMatch	UBERON:6040007	semapv:ManualMappingCuration
+FBbt:00041000	synaptic neuropil block	semapv:crossSpeciesExactMatch	UBERON:6041000	semapv:ManualMappingCuration
+FBbt:00047153	anus	semapv:crossSpeciesExactMatch	UBERON:0001245	semapv:ManualMappingCuration
+FBbt:00048032	glycinergic neuron	semapv:crossSpeciesExactMatch	CL:1001509	semapv:ManualMappingCuration
+FBbt:00057001	anterior-posterior subdivision of organism	semapv:crossSpeciesExactMatch	UBERON:6057001	semapv:ManualMappingCuration
+FBbt:00057012	female germline cell	semapv:crossSpeciesExactMatch	CL:0000025	semapv:ManualMappingCuration
+FBbt:00058291	dorsal vessel	semapv:crossSpeciesExactMatch	UBERON:0015231	semapv:ManualMappingCuration
+FBbt:00100152	row	semapv:crossSpeciesExactMatch	UBERON:0034926	semapv:ManualMappingCuration
+FBbt:00100153	sensillum row	semapv:crossSpeciesExactMatch	UBERON:6100153	semapv:ManualMappingCuration
+FBbt:00100291	glutamatergic neuron	semapv:crossSpeciesExactMatch	CL:0000679	semapv:ManualMappingCuration
+FBbt:00100313	multicellular structure	semapv:crossSpeciesExactMatch	UBERON:0010000	semapv:ManualMappingCuration
+FBbt:00100314	duct	semapv:crossSpeciesExactMatch	UBERON:0000058	semapv:ManualMappingCuration
+FBbt:00100315	gut section	semapv:crossSpeciesExactMatch	UBERON:0004921	semapv:ManualMappingCuration
+FBbt:00100316	diverticulum of gut	semapv:crossSpeciesExactMatch	UBERON:0009854	semapv:ManualMappingCuration
+FBbt:00100317	gland	semapv:crossSpeciesExactMatch	UBERON:0002530	semapv:ManualMappingCuration
+FBbt:00110636	adult cerebral ganglion	semapv:crossSpeciesExactMatch	UBERON:6110636	semapv:ManualMappingCuration
+FBbt:00110746	presumptive prothoracic metatarsus	semapv:crossSpeciesExactMatch	UBERON:6110746	semapv:ManualMappingCuration
+FBbt:00110811	presumptive arista	semapv:crossSpeciesExactMatch	UBERON:6110811	semapv:ManualMappingCuration
+FBbt:10000000	anatomical entity	semapv:crossSpeciesExactMatch	UBERON:0001062	semapv:ManualMappingCuration

--- a/src/ontology/components/exact_mappings.owl
+++ b/src/ontology/components/exact_mappings.owl
@@ -1889,14 +1889,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/FBbt_00004924 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004924">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0006834</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/FBbt_00004927 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004927">
@@ -3085,14 +3077,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007070">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007070</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00007091 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007091">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000202</oboInOwl:hasDbXref>
     </owl:Class>
     
 

--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -179,7 +179,7 @@ mappings.sssom.tsv: mappings.tsv ../scripts/mappings2sssom.awk
 tmp/exact_mapping_template.tsv: mappings.sssom.tsv
 	echo 'ID	Cross-reference' > $@
 	echo 'ID	A oboInOwl:hasDbXref' >> $@
-	sed -n '/skos:exactMatch/p' $< | cut -f1,4 >> $@
+	sed -n '/semapv:crossSpeciesExact/p' $< | cut -f1,4 >> $@
 
 components/exact_mappings.owl: tmp/exact_mapping_template.tsv fbbt-edit.obo
 	$(ROBOT) template --input fbbt-edit.obo --template tmp/exact_mapping_template.tsv \

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -78,7 +78,7 @@ FBbt:00007001	UBERON:0000061	exact	anatomical structure
 FBbt:00004927	UBERON:0000079	exact	male reproductive system
 FBbt:00005099	UBERON:0000122	exact	neuron projection bundle
 FBbt:00003126	UBERON:0000165	exact	adult mouth
-FBbt:00007091	UBERON:0000202	exact	subperineurial glial sheath	Debatable: the subperineurial glia does act “like” a BBB but is it enough to make the two terms equivalent?
+FBbt:00007091	UBERON:0000202	close	subperineurial glial sheath	Debatable: the subperineurial glia does act “like” a BBB but is it enough to make the two terms equivalent?
 FBbt:00004199	UBERON:0000207	exact	lens
 FBbt:00005333	UBERON:0000323	exact	late embryo
 FBbt:00007019	UBERON:0000463	exact	portion of organism substance
@@ -191,7 +191,7 @@ FBbt:00004522	UBERON:0005905	exact	labrum	"Uberon term has “insect labium” a
 FBbt:00005380	UBERON:0006562	exact	pharynx
 FBbt:00003701	UBERON:0006795	exact	adult optic lobe
 FBbt:00007410	UBERON:0006832	exact	tracheal lumen
-FBbt:00004924	UBERON:0006834	exact	uterus	Debatable: The fly uterus is the site of egg fertilisation, not of embryo development (oviposition happens quickly after fertilization, so not a lot of developpment occurs while the egg is still in the uterus)
+FBbt:00004924	UBERON:0006834	close	uterus	Debatable: The fly uterus is the site of egg fertilisation, not of embryo development (oviposition happens quickly after fertilization, so not a lot of developpment occurs while the egg is still in the uterus)
 FBbt:00005756	UBERON:0006866	exact	rectum
 FBbt:00004958	UBERON:0006868	exact	seminal vesicle
 FBbt:00003004	UBERON:0007023	exact	adult

--- a/src/scripts/mappings2sssom.awk
+++ b/src/scripts/mappings2sssom.awk
@@ -4,9 +4,8 @@ BEGIN {
 	print "#  FBbt: \"http://purl.obolibrary.org/obo/FBbt_\"";
 	print "#  UBERON: \"http://purl.obolibrary.org/obo/UBERON_\"";
 	print "#  CL: \"http://purl.obolibrary.org/obo/CL_\"";
-	print "#  skos: \"http://www.w3.org/2004/02/skos/core\"";
 	print "#mapping_provider: \"http://purl.obolibrary.org/obo/FBbt.owl\"";
-	print "subject_id\tsubject_label\tpredicate_id\tobject_id\tmatch_type";
+	print "subject_id\tsubject_label\tpredicate_id\tobject_id\tmapping_justification";
 }
 
 /^#/ { next }
@@ -14,10 +13,13 @@ BEGIN {
 
 {
 	if ( $3 == "exact" ) {
-		predicate = "skos:exactMatch"
+		predicate = "semapv:crossSpeciesExactMatch";
+	}
+	else if ( $3 == "broad" ) {
+		predicate = "semapv:crossSpeciesBroadMatch";
 	}
 	else {
-		predicate = "skos:relatedMatch"
+		predicate = "semapv:crossSpeciesCloseMatch"
 	}
-	print $1"\t"$4"\t"predicate"\t"$2"\tHumanCurated";
+	print $1"\t"$4"\t"predicate"\t"$2"\tsemapv:ManualMappingCuration";
 }


### PR DESCRIPTION
This PR updates the script producing the SSSOM mapping set from the `mappings.tsv` source file so that the mappings now use the newly introduced `semapv:crossSpecies*Match` mapping predicates specifically intended to represent cross-species mappings.