### PR TITLE
Update CL mappings

### DIFF
--- a/src/ontology/components/exact_mappings.owl
+++ b/src/ontology/components/exact_mappings.owl
@@ -1313,6 +1313,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00003360 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003360">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000196</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00003559 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003559">
@@ -1357,6 +1365,14 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003632">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003632</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FBbt_00003686 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003686">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000673</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2348,7 +2364,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005130 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005130">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000381</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000165</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2493,6 +2509,14 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005171">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000372</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FBbt_00005173 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005173">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000380</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3081,6 +3105,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FBbt_00007108 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007108">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000429</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FBbt_00007116 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007116">
@@ -3421,6 +3453,14 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00057012">
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000025</oboInOwl:hasDbXref>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FBbt_00058020 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00058020">
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000482</oboInOwl:hasDbXref>
     </owl:Class>
     
 

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -30,7 +30,7 @@ FBbt:00004861	CL:0000086	exact	germline stem cell
 FBbt:00004910	CL:0000674	exact	stalk follicle cell
 FBbt:00005145	CL:0000340	exact	glioblast
 FBbt:00057012	CL:0000025	exact	female germline cell
-FBbt:00005130	CL:0000381	exact	neurosecretory neuron
+FBbt:00005130	CL:0000165	exact	neurosecretory neuron
 FBbt:00005171	CL:0000372	exact	tormogen cell
 FBbt:00005038	CL:0000307	exact	tracheocyte
 FBbt:00005146	CL:0000338	exact	neuroblast
@@ -65,6 +65,11 @@ FBbt:00100291	CL:0000679	exact	glutamatergic neuron
 FBbt:00048032	CL:1001509	exact	glycinergic neuron
 FBbt:00007367	CL:0011110	exact	histaminergic neuron
 FBbt:00004101	CL:0000110	exact	peptidergic neuron
+FBbt:00007108	CL:0000429	exact	imaginal disc epithelial cell
+FBbt:00003686	CL:0000673	exact	Kenyon cell
+FBbt:00003360	CL:0000196	exact	flight muscle cell
+FBbt:00005173	CL:0000380	exact	thecogen cell
+FBbt:00058020	CL:0000482	exact	juvenile hormone secreting cell
 
 # Imported mappings from UBERON's xrefs
 FBbt:00005157	UBERON:0000005	exact	chemosensory sensory organ


### PR DESCRIPTION
This PR updates the mappings with the cell ontology. It fixes the mapping of FBbt:00005130 from CL:0000381 to CL:0000165 and add some missing mappings mentioned in #1583.