### PR TITLE
Fix neuroepidermoblast

### DIFF
--- a/fbbt-mappings.sssom.tsv
+++ b/fbbt-mappings.sssom.tsv
@@ -306,7 +306,6 @@ FBbt:00005144	glial cell	semapv:crossSpeciesExactMatch	CL:0000125	semapv:ManualM
 FBbt:00005145	glioblast	semapv:crossSpeciesExactMatch	CL:0000340	semapv:ManualMappingCuration
 FBbt:00005146	neuroblast	semapv:crossSpeciesExactMatch	CL:0000338	semapv:ManualMappingCuration
 FBbt:00005147	neuroglioblast	semapv:crossSpeciesExactMatch	CL:0000468	semapv:ManualMappingCuration
-FBbt:00005148	neuroepidermoblast	semapv:crossSpeciesExactMatch	CL:0000405	semapv:ManualMappingCuration
 FBbt:00005149	ganglion mother cell	semapv:crossSpeciesExactMatch	CL:0000469	semapv:ManualMappingCuration
 FBbt:00005155	sense organ	semapv:crossSpeciesExactMatch	UBERON:0000020	semapv:ManualMappingCuration
 FBbt:00005157	chemosensory sensory organ	semapv:crossSpeciesExactMatch	UBERON:0000005	semapv:ManualMappingCuration

--- a/src/ontology/components/exact_mappings.owl
+++ b/src/ontology/components/exact_mappings.owl
@@ -42,7 +42,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000001">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000468</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000468</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -50,7 +50,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000002 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000002">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000002</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000002</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -58,7 +58,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000003">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000914</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000914</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -66,8 +66,8 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000004 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000004">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000033</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000004</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000033</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000004</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -75,7 +75,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000005 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000005">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000005</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000005</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -83,7 +83,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000006 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000006">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000006</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -91,7 +91,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000007 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000007">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000007</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000007</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -99,7 +99,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000008 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000008">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000008</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000008</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -107,7 +107,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000009 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000009">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000009</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000009</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -115,7 +115,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000011 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000011">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000011</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000011</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -123,7 +123,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000014 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000014">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000014</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000014</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -131,7 +131,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000015 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000015">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000015</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000015</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -139,7 +139,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000016 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000016">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000016</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000016</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -147,7 +147,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000017 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000017">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000017</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000017</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -155,7 +155,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000018 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000018">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000018</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000018</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -163,7 +163,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000019 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000019">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000019</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000019</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -171,7 +171,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000020 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000020">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000020</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000020</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -179,7 +179,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000021 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000021">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000021</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000021</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -187,7 +187,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000029 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000029">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000029</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000029</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -195,7 +195,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000030 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000030">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000030</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000030</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -203,7 +203,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000038 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000038">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000920</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000920</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -211,7 +211,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000042 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000042">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003125</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003125</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -219,7 +219,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000046 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000046">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000046</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000046</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -227,7 +227,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000052 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000052">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000922</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000922</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -235,7 +235,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000092 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000092">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000301</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000301</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -243,7 +243,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000093 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000093">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0009571</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0009571</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -251,7 +251,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000095 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000095">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0010302</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0010302</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -259,7 +259,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000096 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000096">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000096</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000096</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -267,7 +267,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000097 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000097">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000097</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000097</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -275,7 +275,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000104 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000104">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000104</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000104</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -283,7 +283,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000110 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000110">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000923</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000923</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -291,7 +291,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000111 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000111">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000924</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000924</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -299,7 +299,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000112 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000112">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000112</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000112</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -307,7 +307,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000119 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000119">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000119</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000119</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -315,7 +315,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000123 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000123">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000931</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000931</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -323,7 +323,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000124 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000124">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000066</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000066</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -331,7 +331,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000125 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000125">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000925</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000925</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -339,7 +339,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000126 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000126">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000926</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000926</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -347,7 +347,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000128 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000128">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000128</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000128</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -355,7 +355,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000130 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000130">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000130</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000130</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -363,7 +363,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000136 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000136">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000927</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000927</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -371,7 +371,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000137 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000137">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000137</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000137</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -379,7 +379,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000154 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000154">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000154</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000154</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -387,7 +387,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000155 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000155">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0008816</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0008816</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -395,7 +395,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000157 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000157">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000157</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000157</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -403,7 +403,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000158 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000158">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000158</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000158</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -411,7 +411,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000160 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000160">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000160</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000160</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -419,7 +419,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000162 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000162">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000162</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000162</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -427,7 +427,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000165 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000165">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000165</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000165</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -435,7 +435,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000166 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000166">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000166</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000166</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -443,7 +443,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000167 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000167">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000167</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000167</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -451,7 +451,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000168 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000168">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000168</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000168</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -459,7 +459,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000169 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000169">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000169</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000169</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -467,7 +467,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000170 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000170">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000170</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000170</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -475,7 +475,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000171 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000171">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000171</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000171</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -483,7 +483,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000172 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000172">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000172</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000172</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -491,7 +491,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000180 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000180">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000180</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000180</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -499,7 +499,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000181 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000181">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000181</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000181</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -507,7 +507,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000186 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000186">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6000186</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6000186</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -515,7 +515,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00000439 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000439">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000930</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000930</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -523,7 +523,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001055 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001055">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001055</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001055</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -531,7 +531,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001056 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001056">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001056</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001056</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -539,7 +539,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001057 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001057">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002346</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0002346</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -547,7 +547,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001059 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001059">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001059</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001059</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -555,7 +555,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001060 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001060">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001060</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001060</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -563,7 +563,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001135 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001135">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001135</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001135</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -571,7 +571,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001648 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001648">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001648</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001648</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -579,7 +579,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001649 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001649">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001649</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001649</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -587,7 +587,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001650 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001650">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001650</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001650</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -595,7 +595,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001652 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001652">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001652</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001652</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -603,7 +603,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001653 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001653">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001653</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001653</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -611,7 +611,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001655 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001655">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001655</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001655</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -619,7 +619,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001656 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001656">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001656</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001656</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -627,7 +627,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001657 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001657">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001657</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001657</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -635,7 +635,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001658 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001658">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001658</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001658</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -643,7 +643,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001661 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001661">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001661</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001661</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -651,7 +651,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001662 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001662">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001662</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001662</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -659,7 +659,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001663 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001663">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001663</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001663</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -667,7 +667,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001664 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001664">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001664</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001664</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -675,7 +675,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001666 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001666">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000465</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000465</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -683,7 +683,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001668 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001668">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001668</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001668</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -691,7 +691,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001685 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001685">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000394</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000394</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -699,7 +699,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001687 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001687">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000396</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000396</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -707,7 +707,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001689 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001689">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000395</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000395</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -715,7 +715,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001690 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001690">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000715</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000715</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -723,7 +723,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001691 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001691">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000398</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000398</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -731,7 +731,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001718 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001718">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0012325</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0012325</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -739,7 +739,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001722 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001722">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001722</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001722</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -747,7 +747,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001727 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001727">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002548</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0002548</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -755,7 +755,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001728 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001728">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001728</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001728</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -763,7 +763,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001729 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001729">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001729</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001729</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -771,7 +771,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001730 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001730">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001730</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001730</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -779,7 +779,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001731 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001731">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001731</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001731</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -787,7 +787,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001732 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001732">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001732</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001732</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -795,7 +795,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001733 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001733">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001733</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001733</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -803,7 +803,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001734 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001734">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001734</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001734</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -811,7 +811,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001735 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001735">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001735</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001735</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -819,7 +819,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001737 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001737">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001737</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001737</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -827,7 +827,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001740 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001740">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001740</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001740</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -835,7 +835,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001741 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001741">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001741</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001741</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -843,7 +843,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001742 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001742">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001742</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001742</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -851,7 +851,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001743 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001743">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001743</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001743</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -859,7 +859,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001744 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001744">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001744</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001744</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -867,7 +867,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001745 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001745">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001745</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001745</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -875,7 +875,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001746 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001746">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001746</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001746</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -883,7 +883,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001747 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001747">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001747</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001747</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -891,7 +891,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001755 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001755">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001755</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001755</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -899,7 +899,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001756 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001756">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001756</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001756</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -907,7 +907,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001760 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001760">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001760</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001760</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -915,7 +915,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001761 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001761">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000939</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000939</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -923,7 +923,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001764 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001764">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001764</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001764</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -931,7 +931,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001765 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001765">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001765</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001765</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -939,7 +939,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001766 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001766">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001766</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001766</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -947,7 +947,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001767 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001767">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001767</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001767</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -955,7 +955,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001776 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001776">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001776</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001776</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -963,7 +963,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001778 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001778">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001778</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001778</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -971,7 +971,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001779 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001779">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001779</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001779</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -979,7 +979,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001780 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001780">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001780</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001780</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -987,7 +987,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001781 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001781">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001781</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001781</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -995,7 +995,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001784 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001784">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001784</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001784</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1003,7 +1003,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001785 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001785">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001785</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001785</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1011,7 +1011,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001787 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001787">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001787</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001787</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1019,8 +1019,8 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001789 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001789">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000373</oboInOwl:hasDbXref>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001789</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000373</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001789</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1028,7 +1028,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001790 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001790">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001790</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001790</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1036,7 +1036,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001791 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001791">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001791</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001791</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1044,7 +1044,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001792 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001792">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001792</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001792</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1052,7 +1052,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001809 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001809">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001809</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001809</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1060,7 +1060,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001842 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001842">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001842</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001842</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1068,7 +1068,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001845 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001845">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001845</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001845</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1076,7 +1076,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001848 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001848">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001848</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001848</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1084,7 +1084,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001911 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001911">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001911</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001911</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1092,7 +1092,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001919 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001919">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001919</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001919</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1100,7 +1100,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001920 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001920">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001920</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001920</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1108,7 +1108,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001925 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001925">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6001925</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6001925</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1116,7 +1116,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00001956 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00001956">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0004904</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0004904</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1124,7 +1124,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00002639 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00002639">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6002639</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6002639</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1132,7 +1132,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00002642 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00002642">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6002642</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6002642</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1140,7 +1140,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00002952 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00002952">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003142</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003142</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1148,7 +1148,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00002953 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00002953">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003143</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003143</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1156,7 +1156,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003004 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003004">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0007023</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0007023</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1164,7 +1164,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003005 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003005">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003005</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003005</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1172,7 +1172,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003006 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003006">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003006</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1180,7 +1180,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003007 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003007">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003007</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003007</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1188,7 +1188,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003009 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003009">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003009</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003009</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1196,7 +1196,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003010 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003010">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003010</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003010</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1204,7 +1204,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003011 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003011">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003011</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003011</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1212,7 +1212,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003012 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003012">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003012</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003012</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1220,7 +1220,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003018 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003018">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003018</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003018</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1228,7 +1228,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003019 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003019">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003019</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003019</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1236,7 +1236,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003020 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003020">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003020</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003020</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1244,7 +1244,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003021 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003021">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003021</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003021</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1252,7 +1252,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003023 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003023">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003023</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003023</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1260,7 +1260,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003024 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003024">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003024</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003024</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1268,7 +1268,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003039 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003039">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003039</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003039</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1276,7 +1276,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003125 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003125">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001555</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001555</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1284,7 +1284,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003126 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003126">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000165</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000165</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1292,7 +1292,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003154 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003154">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0015230</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0015230</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1300,7 +1300,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003219 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003219">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000462</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000462</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1308,7 +1308,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003259 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003259">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003259</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003259</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1316,7 +1316,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003360 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003360">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000196</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000196</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1324,7 +1324,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003559 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003559">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003559</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003559</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1332,7 +1332,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003623 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003623">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003623</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003623</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1340,7 +1340,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003624 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003624">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003624</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003624</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1348,7 +1348,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003626 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003626">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003626</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003626</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1356,7 +1356,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003627 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003627">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003627</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003627</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1364,7 +1364,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003632 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003632">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6003632</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6003632</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1372,7 +1372,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003686 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003686">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000673</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000673</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1380,7 +1380,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00003701 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00003701">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0006795</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0006795</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1388,7 +1388,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004101 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004101">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000110</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000110</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1396,7 +1396,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004114 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004114">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000963</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000963</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1404,7 +1404,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004193 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004193">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000718</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000718</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1412,7 +1412,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004199 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004199">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000207</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000207</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1420,7 +1420,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004200 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004200">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0005388</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0005388</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1428,7 +1428,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004203 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004203">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004203</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004203</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1436,7 +1436,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004208 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004208">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002050</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0002050</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1444,7 +1444,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004211 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004211">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:2000019</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:2000019</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1452,7 +1452,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004230 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004230">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0001658</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0001658</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1460,7 +1460,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004296 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004296">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004296</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004296</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1468,7 +1468,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004340 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004340">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004340</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004340</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1476,7 +1476,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004475 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004475">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004475</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004475</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1484,7 +1484,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004476 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004476">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004476</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004476</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1492,7 +1492,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004477 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004477">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004477</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004477</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1500,7 +1500,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004481 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004481">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004481</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004481</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1508,7 +1508,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004492 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004492">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003155</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003155</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1516,7 +1516,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004505 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004505">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003161</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003161</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1524,7 +1524,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004506 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004506">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003162</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003162</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1532,7 +1532,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004507 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004507">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003211</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003211</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1540,7 +1540,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004508 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004508">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000018</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000018</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1548,7 +1548,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004510 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004510">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000971</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000971</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1556,7 +1556,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004511 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004511">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000972</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000972</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1564,7 +1564,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004519 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004519">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004519</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004519</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1572,7 +1572,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004520 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004520">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004520</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004520</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1580,7 +1580,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004521 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004521">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004521</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004521</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1588,7 +1588,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004522 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004522">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0005905</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0005905</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1596,7 +1596,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004535 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004535">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004535</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004535</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1604,7 +1604,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004540 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004540">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004540</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004540</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1612,7 +1612,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004551 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004551">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004551</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004551</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1620,7 +1620,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004552 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004552">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004552</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004552</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1628,7 +1628,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004557 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004557">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003130</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003130</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1636,7 +1636,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004578 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004578">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004578</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004578</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1644,7 +1644,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004579 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004579">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004579</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004579</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1652,7 +1652,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004580 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004580">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004580</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004580</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1660,7 +1660,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004640 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004640">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0005895</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0005895</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1668,7 +1668,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004642 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004642">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003131</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003131</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1676,7 +1676,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004646 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004646">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004646</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004646</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1684,7 +1684,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004648 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004648">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004648</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004648</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1692,7 +1692,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004663 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004663">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004663</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004663</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1700,7 +1700,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004668 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004668">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004668</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004668</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1708,7 +1708,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004670 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004670">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004670</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004670</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1716,7 +1716,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004729 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004729">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000984</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000984</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1724,7 +1724,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004751 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004751">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003194</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003194</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1732,7 +1732,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004783 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004783">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000987</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000987</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1740,7 +1740,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004788 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004788">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004788</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004788</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1748,7 +1748,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004823 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004823">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004823</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004823</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1756,7 +1756,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004824 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004824">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004824</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004824</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1764,7 +1764,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004825 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004825">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004825</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004825</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1772,7 +1772,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004850 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004850">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0008811</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0008811</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1780,7 +1780,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004856 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004856">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000467</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000467</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1788,7 +1788,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004857 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004857">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000990</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000990</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1796,7 +1796,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004858 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004858">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000991</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000991</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1804,7 +1804,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004861 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004861">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000086</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000086</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1812,7 +1812,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004864 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004864">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000474</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000474</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1820,7 +1820,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004865 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004865">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000992</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000992</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1828,7 +1828,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004873 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004873">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000022</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000022</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1836,7 +1836,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004878 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004878">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000026</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000026</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1844,7 +1844,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004886 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004886">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000023</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000023</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1852,7 +1852,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004894 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004894">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003199</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003199</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1860,7 +1860,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004903 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004903">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000441</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000441</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1868,7 +1868,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004904 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004904">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000477</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000477</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1876,7 +1876,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004905 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004905">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000579</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000579</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1884,7 +1884,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004906 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004906">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000671</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000671</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1892,7 +1892,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004910 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004910">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000674</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000674</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1900,7 +1900,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004921 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004921">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000994</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000994</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1908,7 +1908,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004927 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004927">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000079</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000079</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1916,7 +1916,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004928 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004928">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000473</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000473</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1924,7 +1924,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004929 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004929">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000087</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000087</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1932,7 +1932,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004934 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004934">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000020</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000020</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1940,7 +1940,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004935 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004935">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000020</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000020</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1948,7 +1948,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004936 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004936">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000017</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000017</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1956,7 +1956,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004941 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004941">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000657</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000657</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1964,7 +1964,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004942 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004942">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000018</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000018</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1972,7 +1972,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004954 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004954">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000019</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000019</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1980,7 +1980,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004958 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004958">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0006868</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0006868</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1988,7 +1988,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004969 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004969">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002416</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0002416</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -1996,7 +1996,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004970 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004970">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001001</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001001</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2004,7 +2004,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004973 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004973">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003201</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003201</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2012,7 +2012,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004974 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004974">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003202</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003202</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2020,7 +2020,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004979 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004979">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004979</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004979</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2028,7 +2028,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004983 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004983">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004983</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004983</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2036,7 +2036,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004986 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004986">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6004986</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6004986</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2044,7 +2044,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004987 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004987">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0018656</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0018656</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2052,7 +2052,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004993 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004993">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0007376</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0007376</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2060,7 +2060,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004994 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004994">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000464</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000464</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2068,7 +2068,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00004995 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00004995">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000487</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000487</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2076,7 +2076,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005023 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005023">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005023</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005023</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2084,7 +2084,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005024 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005024">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0005155</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0005155</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2092,7 +2092,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005036 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005036">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005036</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005036</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2100,7 +2100,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005037 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005037">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005037</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005037</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2108,7 +2108,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005038 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005038">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000307</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000307</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2116,7 +2116,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005043 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005043">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005043</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005043</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2124,7 +2124,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005054 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005054">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005054</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005054</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2132,7 +2132,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005055 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005055">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001007</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001007</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2140,7 +2140,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005056 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005056">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001008</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001008</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2148,7 +2148,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005057 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005057">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0009054</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0009054</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2156,7 +2156,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005058 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005058">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000474</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000474</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2164,7 +2164,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005059 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005059">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000486</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000486</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2172,7 +2172,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005060 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005060">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002323</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0002323</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2180,7 +2180,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005061 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005061">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001011</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001011</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2188,7 +2188,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005062 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005062">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000385</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000385</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2196,7 +2196,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005063 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005063">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000387</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000387</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2204,7 +2204,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005066 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005066">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003917</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003917</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2212,7 +2212,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005068 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005068">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000949</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000949</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2220,7 +2220,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005070 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005070">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0008007</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0008007</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2228,7 +2228,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005073 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005073">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0008004</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0008004</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2236,7 +2236,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005074 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005074">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000187</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000187</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2244,7 +2244,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005083 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005083">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000056</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000056</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2252,7 +2252,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005093 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005093">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001016</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001016</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2260,7 +2260,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005094 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005094">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001017</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001017</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2268,7 +2268,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005095 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005095">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000955</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000955</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2276,7 +2276,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005096 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005096">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005096</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005096</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2284,7 +2284,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005097 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005097">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000934</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000934</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2292,7 +2292,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005098 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005098">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000010</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000010</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2300,7 +2300,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005099 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005099">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000122</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000122</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2308,7 +2308,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005100 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005100">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001018</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001018</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2316,7 +2316,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005105 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005105">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001021</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001021</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2324,7 +2324,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005106 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005106">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000540</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000540</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2332,7 +2332,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005123 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005123">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000100</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000100</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2340,7 +2340,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005124 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005124">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000101</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000101</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2348,7 +2348,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005125 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005125">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000099</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000099</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2356,7 +2356,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005128 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005128">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000116</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000116</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2364,7 +2364,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005130 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005130">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000165</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000165</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2372,7 +2372,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005131 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005131">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000700</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000700</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2380,7 +2380,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005133 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005133">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000850</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000850</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2388,7 +2388,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005136 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005136">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001027</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001027</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2396,7 +2396,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005139 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005139">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002606</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0002606</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2404,7 +2404,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005144 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005144">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000125</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000125</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2412,7 +2412,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005145 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005145">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000340</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000340</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2420,7 +2420,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005146 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005146">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000338</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000338</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2428,15 +2428,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005147 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005147">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000468</oboInOwl:hasDbXref>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/FBbt_00005148 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005148">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000405</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000468</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2444,7 +2436,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005149 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005149">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000469</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000469</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2452,7 +2444,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005155 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005155">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000020</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000020</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2460,7 +2452,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005157 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005157">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000005</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000005</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2468,7 +2460,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005158 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005158">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002268</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0002268</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2476,7 +2468,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005159 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005159">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003212</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003212</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2484,7 +2476,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005162 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005162">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000970</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000970</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2492,7 +2484,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005168 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005168">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005168</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005168</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2500,7 +2492,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005169 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005169">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000374</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000374</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2508,7 +2500,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005171 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005171">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000372</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000372</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2516,7 +2508,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005173 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005173">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000380</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000380</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2524,7 +2516,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005177 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005177">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005177</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005177</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2532,7 +2524,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005215 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005215">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001038</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001038</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2540,7 +2532,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005219 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005219">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000382</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000382</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2548,7 +2540,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005221 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005221">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000407</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000407</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2556,7 +2548,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005317 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005317">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0004734</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0004734</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2564,7 +2556,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005333 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005333">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000323</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000323</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2572,7 +2564,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005338 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005338">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0018382</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0018382</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2580,7 +2572,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005378 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005378">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005378</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005378</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2588,7 +2580,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005379 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005379">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001041</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001041</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2596,7 +2588,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005380 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005380">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0006562</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0006562</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2604,7 +2596,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005382 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005382">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001044</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001044</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2612,7 +2604,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005383 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005383">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001045</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001045</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2620,7 +2612,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005384 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005384">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001046</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001046</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2628,7 +2620,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005386 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005386">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001047</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001047</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2636,7 +2628,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005393 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005393">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005393</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005393</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2644,7 +2636,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005396 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005396">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005396</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005396</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2652,7 +2644,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005412 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005412">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000300</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000300</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2660,7 +2652,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005413 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005413">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005413</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005413</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2668,7 +2660,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005426 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005426">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0007688</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0007688</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2676,7 +2668,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005427 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005427">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005427</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005427</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2684,7 +2676,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005428 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005428">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005428</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005428</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2692,7 +2684,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005434 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005434">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005434</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005434</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2700,7 +2692,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005436 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005436">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005436</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005436</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2708,7 +2700,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005439 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005439">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005439</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005439</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2716,7 +2708,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005461 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005461">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005461</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005461</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2724,7 +2716,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005467 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005467">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005467</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005467</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2732,7 +2724,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005495 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005495">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001048</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001048</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2740,7 +2732,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005514 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005514">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005514</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005514</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2748,7 +2740,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005526 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005526">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005526</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005526</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2756,7 +2748,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005533 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005533">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005533</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005533</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2764,7 +2756,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005538 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005538">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005538</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005538</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2772,7 +2764,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005558 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005558">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005558</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005558</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2780,7 +2772,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005569 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005569">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005569</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005569</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2788,7 +2780,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005756 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005756">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0006866</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0006866</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2796,7 +2788,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005757 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005757">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001053</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001053</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2804,7 +2796,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005786 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005786">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001054</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001054</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2812,7 +2804,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005797 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005797">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:1000155</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:1000155</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2820,7 +2812,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005799 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005799">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001056</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001056</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2828,7 +2820,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005800 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005800">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001057</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001057</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2836,7 +2828,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005801 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005801">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001058</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001058</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2844,7 +2836,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005802 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005802">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001059</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001059</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2852,7 +2844,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005805 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005805">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005805</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005805</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2860,7 +2852,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005811 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005811">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0004905</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0004905</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2868,7 +2860,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005812 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005812">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0002372</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0002372</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2876,7 +2868,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005830 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005830">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005830</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005830</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2884,7 +2876,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005831 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005831">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005831</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005831</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2892,7 +2884,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005835 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005835">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000478</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000478</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2900,7 +2892,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005913 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005913">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6005913</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6005913</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2908,7 +2900,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00005917 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00005917">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000735</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000735</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2916,7 +2908,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00006011 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00006011">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6006011</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6006011</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2924,7 +2916,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00006032 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00006032">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6006032</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6006032</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2932,7 +2924,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007000">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000026</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000026</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2940,7 +2932,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007001">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000061</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000061</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2948,7 +2940,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007002 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007002">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000000</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2956,7 +2948,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007003">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000479</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000479</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2964,7 +2956,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007004 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007004">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003101</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003101</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2972,7 +2964,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007005 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007005">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000483</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000483</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2980,7 +2972,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007006 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007006">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0005423</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0005423</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2988,7 +2980,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007009 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007009">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000475</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000475</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -2996,7 +2988,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007010 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007010">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000481</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000481</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3004,7 +2996,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007011 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007011">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003100</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003100</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3012,7 +3004,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007013 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007013">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000476</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000476</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3020,7 +3012,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007015 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007015">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000466</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000466</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3028,7 +3020,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007016 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007016">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000465</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000465</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3036,7 +3028,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007017 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007017">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000464</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000464</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3044,7 +3036,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007018 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007018">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0010758</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0010758</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3052,7 +3044,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007019 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007019">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000463</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000463</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3060,7 +3052,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007020 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007020">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007020</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007020</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3068,7 +3060,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007027 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007027">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000485</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000485</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3076,7 +3068,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007045 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007045">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007045</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007045</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3084,7 +3076,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007046 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007046">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007046</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007046</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3092,7 +3084,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007060 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007060">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0005162</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0005162</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3100,7 +3092,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007070 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007070">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007070</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007070</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3108,7 +3100,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007108 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007108">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000429</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000429</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3116,7 +3108,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007116 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007116">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007116</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007116</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3124,7 +3116,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007145 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007145">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007145</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007145</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3132,7 +3124,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007149 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007149">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007149</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007149</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3140,7 +3132,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007150 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007150">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007150</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007150</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3148,7 +3140,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007152 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007152">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002536</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0002536</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3156,7 +3148,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007173 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007173">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000108</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000108</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3164,7 +3156,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007228 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007228">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000617</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000617</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3172,7 +3164,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007229 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007229">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0010001</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0010001</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3180,7 +3172,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007230 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007230">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0014732</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0014732</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3188,7 +3180,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007231 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007231">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007231</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007231</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3196,7 +3188,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007232 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007232">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007232</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007232</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3204,7 +3196,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007233 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007233">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007233</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007233</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3212,7 +3204,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007240 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007240">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007240</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007240</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3220,7 +3212,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007242 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007242">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007242</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007242</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3228,7 +3220,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007245 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007245">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007245</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007245</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3236,7 +3228,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007248 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007248">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007248</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007248</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3244,7 +3236,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007276 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007276">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0034923</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0034923</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3252,7 +3244,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007277 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007277">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000477</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000477</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3260,7 +3252,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007278 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007278">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0015203</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0015203</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3268,7 +3260,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007280 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007280">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007280</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007280</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3276,7 +3268,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007284 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007284">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007284</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007284</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3284,7 +3276,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007285 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007285">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007285</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007285</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3292,7 +3284,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007288 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007288">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007288</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007288</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3300,7 +3292,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007289 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007289">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007289</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007289</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3308,7 +3300,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007325 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007325">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000463</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000463</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3316,7 +3308,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007330 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007330">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0011216</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0011216</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3324,7 +3316,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007331 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007331">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007331</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007331</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3332,7 +3324,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007367 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007367">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0011110</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0011110</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3340,7 +3332,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007373 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007373">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007373</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007373</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3348,7 +3340,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007410 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007410">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0006832</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0006832</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3356,7 +3348,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007424 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007424">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6007424</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6007424</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3364,7 +3356,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007474 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007474">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0003914</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0003914</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3372,7 +3364,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00007692 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00007692">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001032</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001032</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3380,7 +3372,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00016022 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00016022">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6016022</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6016022</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3388,7 +3380,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00017021 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00017021">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6017021</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6017021</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3396,7 +3388,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00040003 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00040003">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6040003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6040003</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3404,7 +3396,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00040005 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00040005">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6040005</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6040005</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3412,7 +3404,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00040007 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00040007">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6040007</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6040007</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3420,7 +3412,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00041000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00041000">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6041000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6041000</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3428,7 +3420,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00047153 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00047153">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001245</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001245</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3436,7 +3428,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00048032 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00048032">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:1001509</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:1001509</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3444,7 +3436,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00057001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00057001">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6057001</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6057001</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3452,7 +3444,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00057012 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00057012">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000025</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000025</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3460,7 +3452,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00058020 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00058020">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000482</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000482</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3468,7 +3460,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00058291 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00058291">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0015231</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0015231</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3476,7 +3468,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00100152 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00100152">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0034926</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0034926</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3484,7 +3476,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00100153 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00100153">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6100153</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6100153</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3492,7 +3484,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00100291 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00100291">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000679</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>CL:0000679</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3500,7 +3492,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00100313 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00100313">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0010000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0010000</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3508,7 +3500,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00100314 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00100314">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000058</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0000058</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3516,7 +3508,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00100315 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00100315">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0004921</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0004921</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3524,7 +3516,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00100316 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00100316">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0009854</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0009854</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3532,7 +3524,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00100317 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00100317">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002530</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0002530</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3540,7 +3532,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00110636 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00110636">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6110636</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6110636</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3548,7 +3540,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00110746 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00110746">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6110746</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6110746</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3556,7 +3548,7 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_00110811 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00110811">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:6110811</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:6110811</oboInOwl:hasDbXref>
     </owl:Class>
     
 
@@ -3564,11 +3556,11 @@
     <!-- http://purl.obolibrary.org/obo/FBbt_10000000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_10000000">
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001062</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>UBERON:0001062</oboInOwl:hasDbXref>
     </owl:Class>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.25) https://github.com/owlcs/owlapi -->
 

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -36,7 +36,6 @@ FBbt:00005038	CL:0000307	exact	tracheocyte
 FBbt:00005146	CL:0000338	exact	neuroblast
 FBbt:00005062	CL:0000385	exact	prohemocyte
 FBbt:00004873	CL:0000022	exact	female germline stem cell
-FBbt:00005148	CL:0000405	exact	neuroepidermoblast
 FBbt:00005147	CL:0000468	exact	neuroglioblast
 FBbt:00005149	CL:0000469	exact	ganglion mother cell
 FBbt:00001687	CL:0000396	exact	lamellocyte


### PR DESCRIPTION
Add a proper definition to _neuroepidermoblast_. Also re-classify as a _somatic precursor cell_ rather than as _neuroblast_, since a neuroepidermoblast, as the term is understood, is a cell that _may_ become a neuroblast but has not yet done so (and it may become an   epidermoblast instead, thereby never entering the neural lineage). Assert it as part of a proneural cluster, with a _proneural cluster cell_ synonym.
    
Remove the mapping with the equivalent term in CL, as I plan to obsolete the CL term (CL does not need such a precise term, especially since the term is actually never used in the literature).
    
closes #1621