### PR TITLE
Update mappings

### DIFF
--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -11,7 +11,7 @@ FBbt:00007002	CL:0000000	exact	cell
 FBbt:00001690	CL:0000715	exact	embryonic/larval crystal cell
 FBbt:00004942	CL:0000018	exact	spermatid
 FBbt:00005074	CL:0000187	exact	muscle cell
-FBbt:00004929	CL:0000087	exact	male germline stem cell
+FBbt:00004929	CL:0000016	exact	male germline stem cell
 FBbt:00004886	CL:0000023	exact	oocyte
 FBbt:00004193	CL:0000718	exact	cone cell
 FBbt:00004230	CL:0001658	exact	pigment cell
@@ -26,7 +26,7 @@ FBbt:00004905	CL:0000579	exact	border follicle cell
 FBbt:00005412	CL:0000300	exact	gamete
 FBbt:00004936	CL:0000017	exact	spermatocyte
 FBbt:00004906	CL:0000671	exact	centripetal follicle cell
-FBbt:00004861	CL:0000086	exact	germline stem cell
+FBbt:00004861	CL:0000014	exact	germline stem cell
 FBbt:00004910	CL:0000674	exact	stalk follicle cell
 FBbt:00005145	CL:0000340	exact	glioblast
 FBbt:00057012	CL:0000025	exact	female germline cell

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -32,7 +32,7 @@ FBbt:00005145	CL:0000340	exact	glioblast
 FBbt:00057012	CL:0000025	exact	female germline cell
 FBbt:00005130	CL:0000165	exact	neurosecretory neuron
 FBbt:00005171	CL:0000372	exact	tormogen cell
-FBbt:00005038	CL:0000307	exact	tracheocyte
+FBbt:00005038	CL:0008026	exact	tracheocyte
 FBbt:00005146	CL:0000338	exact	neuroblast
 FBbt:00005062	CL:0000385	exact	prohemocyte
 FBbt:00004873	CL:0000022	exact	female germline stem cell

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -316,11 +316,7 @@ FBbt:00001781	UBERON:6001781	exact	prothoracic leg disc
 FBbt:00001784	UBERON:6001784	exact	genital disc
 FBbt:00001785	UBERON:6001785	exact	male genital disc
 FBbt:00001787	UBERON:6001787	exact	female genital disc
-FBbt:00001789	UBERON:6001789	exact	histoblast	Uberon term probably belongs in CL
-FBbt:00001790	UBERON:6001790	exact	histoblast nest	Uberon term is misclassified (under histoblast)
-FBbt:00001791	UBERON:6001791	exact	dorsal histoblast nest abdominal
-FBbt:00001792	UBERON:6001792	exact	anterior dorsal histoblast nest abdominal
-FBbt:00001809	UBERON:6001809	exact	posterior dorsal histoblast nest abdominal
+FBbt:00001790	UBERON:6001790	exact	histoblast nest
 FBbt:00001842	UBERON:6001842	exact	embryonic/larval digestive system
 FBbt:00001845	UBERON:6001845	exact	cephalopharyngeal skeleton
 FBbt:00001848	UBERON:6001848	exact	epipharyngeal sclerite

--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -70,6 +70,9 @@ FBbt:00003360	CL:0000196	exact	flight muscle cell
 FBbt:00005173	CL:0000380	exact	thecogen cell
 FBbt:00058020	CL:0000482	exact	juvenile hormone secreting cell
 
+# Mappings with UBERON
+FBbt:00004482	UBERON:0003153	exact	head capsule
+
 # Imported mappings from UBERON's xrefs
 FBbt:00005157	UBERON:0000005	exact	chemosensory sensory organ
 FBbt:00005098	UBERON:0000010	exact	peripheral nervous system


### PR DESCRIPTION
This PR fixes a handful of issues with the Uberon/CL mappings:

* add missing mapping from [head capsule](http://purl.obolibrary.org/obo/FBbt_00004482) to UBERON’s [insect head capsule](http://purl.obolibrary.org/obo/UBERON_0003153);
* update mapping from [germline stem cell](http://purl.obolibrary.org/obo/FBbt_00004861) to CL’s [germ line stem cell](http://purl.obolibrary.org/obo/CL_0000014) (instead of the now obsoleted clade-specific variant); likewise for [male germline stem cell](http://purl.obolibrary.org/obo/FBbt_00004929);
* Remove mappings to Uberon’s [histoblast](http://purl.obolibrary.org/obo/UBERON_6001789) (obsoleted in favour of the corresponding term in CL) and other related terms;
* Remap [tracheocyte](http://purl.obolibrary.org/obo/FBbt_00005038) to CL’s [open tracheal system tracheocyte](http://purl.obolibrary.org/obo/CL_0008026) instead of [tracheal epithelial cell](http://purl.obolibrary.org/obo/CL_0000307), as the latter is vertebrate-specific.