### PR TITLE
Add missing haltere and wing motor neurons

### DIFF
--- a/src/patterns/data/logical-only/muscleCellByMuscle.tsv
+++ b/src/patterns/data/logical-only/muscleCellByMuscle.tsv
@@ -860,3 +860,4 @@ FBbt:00005651	embryonic hypodermal muscle cell	FBbt:00059034	embryonic hypoderma
 FBbt:00005087	synchronous muscle cell	FBbt:00059030	synchronous muscle
 FBbt:00013333	spiracular occlusor muscle cell	FBbt:00059064	spiracular occlusor muscle
 FBbt:00005088	asynchronous muscle cell	FBbt:00059031	asynchronous muscle
+FBbt:00059259	haltere steering muscle cell	FBbt:00059258	haltere steering muscle

--- a/src/patterns/definitions.owl
+++ b/src/patterns/definitions.owl
@@ -7,8 +7,8 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/fbbt/patterns/definitions.owl>
-<http://purl.obolibrary.org/obo/fbbt/releases/2023-05-03/patterns/definitions.owl>
-Annotation(owl:versionInfo "2023-05-03")
+<http://purl.obolibrary.org/obo/fbbt/releases/2023-06-27/patterns/definitions.owl>
+Annotation(owl:versionInfo "2023-06-27")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00000011>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00000012>))
@@ -3619,6 +3619,8 @@ Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00059236>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00059237>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00059238>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00059239>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00059258>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00059259>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00067123>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00067346>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FBbt_00067347>))
@@ -16236,6 +16238,10 @@ AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#has
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/FBbt_00059239> "LHAV9 neuron")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/FBbt_00059239> "adult lateral horn AV9 neuron")
 EquivalentClasses(<http://purl.obolibrary.org/obo/FBbt_00059239> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/FBbt_00005106> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002101> <http://purl.obolibrary.org/obo/FBbt_00051751>)))
+
+# Class: <http://purl.obolibrary.org/obo/FBbt_00059259> (<http://purl.obolibrary.org/obo/FBbt_00059259>)
+
+EquivalentClasses(<http://purl.obolibrary.org/obo/FBbt_00059259> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/FBbt_00005074> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/FBbt_00059258>)))
 
 # Class: <http://purl.obolibrary.org/obo/FBbt_00067349> (<http://purl.obolibrary.org/obo/FBbt_00067349>)
 


### PR DESCRIPTION
This PR:

* adds synonyms to the existing terms representing the muscles of the haltere, based on the nomenclature used in Dickerson et al., (2019; FBrf0243782);
* adds a new term `haltere steering muscle` to regroup the haltere synchronous axillary muscles (muscle 78) and basalar muscles (muscle 78a) and distinguish them from the haltere asynchronous (“power”) muscle (muscle 77);
* adds new terms representing the motor neurons for all three types of haltere muscle
  * `haltere dorsal ventral muscle motor neuron` (“hDVM motor neuron”),
  * `haltere axillary muscle motor neuron`,
  * `haltere basalar muscle motor neuron`,
* adds a new term for the motor neuron of the wing dorsal ventral indirect flight muscle (wDVM).

closes #1638 