### PR TITLE
Add "enterocyte of adult middle midgut" and related terms for PMID37722602

### DIFF
--- a/src/ontology/components/flybase_import.owl
+++ b/src/ontology/components/flybase_import.owl
@@ -43,24 +43,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000137">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AS-C T8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AS-C T8ase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AS-T8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Asense</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3258</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EG:165H7.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T1A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T1a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">as-T8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ascT8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">asense</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bHLHc28</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sc/T8</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ase</rdfs:label>
+        <oboInOwl:hasExactSynonym>AS-C T8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AS-C T8ase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AS-T8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ASC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Asense</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3258</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EG:165H7.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>T1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>T1A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>T1a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>T8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>as-T8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ascT8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>asense</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bHLHc28</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sc/T8</oboInOwl:hasExactSynonym>
+        <rdfs:label>ase</rdfs:label>
     </owl:Class>
     
 
@@ -69,26 +69,26 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000157">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2.7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Art</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ba</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:LP01770</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brista</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3629</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DLL</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Distal-less</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Distall-less</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Distalless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Distallless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E(Arp)</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">En(Arp)</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enhancer of Arp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">distal-less</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">distalless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dll</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)01092</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)387</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dll</rdfs:label>
+        <oboInOwl:hasExactSynonym>2.7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Art</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ba</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BcDNA:LP01770</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Brista</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3629</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DLL</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Distal-less</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Distall-less</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Distalless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Distallless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>E(Arp)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>En(Arp)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Enhancer of Arp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>distal-less</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>distalless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dll</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)01092</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)387</oboInOwl:hasExactSynonym>
+        <rdfs:label>Dll</rdfs:label>
     </owl:Class>
     
 
@@ -97,24 +97,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000158">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BAM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bag of Marbles</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bag of marbles</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bag-of-Marbles</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bag-of-marbles</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bam</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bam-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BamC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BamF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10422</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bag of marble</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bag of marbles</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bag-of-marbles</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(3)neo61</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ham</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transcript alpha</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bam</rdfs:label>
+        <oboInOwl:hasExactSynonym>BAM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bag of Marbles</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bag of marbles</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bag-of-Marbles</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bag-of-marbles</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bam</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bam-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BamC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BamF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG10422</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>alpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bag of marble</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bag of marbles</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bag-of-marbles</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(3)neo61</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ham</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>transcript alpha</oboInOwl:hasExactSynonym>
+        <rdfs:label>bam</rdfs:label>
     </owl:Class>
     
 
@@ -123,35 +123,35 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000179">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BI</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3578</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-OMB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-omb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OMB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Omb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Optimotor-blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Optomotor blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Optomotor-blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Qd</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Quadroon</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TBX2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bifid</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dm-omb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)bi</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)omb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lethal(l)optomotor-blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">omb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">opomoter-blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optimotor blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optomer-blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optomoter blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optomoter-blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optomotor blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optomotor-blind</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optomotor-blind gene</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optomotorblind</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bi</rdfs:label>
+        <oboInOwl:hasExactSynonym>BI</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3578</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-OMB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-omb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OMB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Omb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Optimotor-blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Optomotor blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Optomotor-blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Qd</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Quadroon</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>T3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TBX2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bifid</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dm-omb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)bi</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)omb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lethal(l)optomotor-blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>omb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>opomoter-blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>optimotor blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>optomer-blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>optomoter blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>optomoter-blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>optomotor blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>optomotor-blind</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>optomotor-blind gene</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>optomotorblind</oboInOwl:hasExactSynonym>
+        <rdfs:label>bi</rdfs:label>
     </owl:Class>
     
 
@@ -160,19 +160,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000395">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BMPER</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15671</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT35855</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CV2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crossveinless 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cv 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cv-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cv2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crossveinless 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crossveinless-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cv 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cv2</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cv-2</rdfs:label>
+        <oboInOwl:hasExactSynonym>BMPER</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG15671</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT35855</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CV2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Crossveinless 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cv 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cv-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cv2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>crossveinless 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>crossveinless-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cv 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cv2</oboInOwl:hasExactSynonym>
+        <rdfs:label>cv-2</rdfs:label>
     </owl:Class>
     
 
@@ -181,36 +181,34 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000463">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0495/20</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0926/11</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1053/14</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1119/09</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1304/03</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1423/11</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1440/11</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1485/04</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3619</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT12133</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Complementation group 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DL</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Delta</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Deltal</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E(ls)2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EC3-5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Overflow</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0118547.269</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">delta</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">delta D1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dmDelta</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)05151</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)92Ab</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)j8C3</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Delta</rdfs:label>
+        <oboInOwl:hasExactSynonym>0495/20</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0926/11</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1053/14</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1119/09</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1304/03</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1423/11</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1440/11</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1485/04</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>C1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3619</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT12133</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Complementation group 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DL</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Delta</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Deltal</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dl</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>E(ls)2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EC3-5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Overflow</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0118547.269</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>delta</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>delta D1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dmDelta</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)05151</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)92Ab</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)j8C3</oboInOwl:hasExactSynonym>
+        <rdfs:label>Delta</rdfs:label>
     </owl:Class>
     
 
@@ -219,40 +217,40 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000490">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BMP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bmp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG9885</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DPP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DPP-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decapentaplegic</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decapentaplegic/Bone Morphogenetic Protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-DPP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmDPP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dpp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dpp/TGFbeta</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haplo-insufficient</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hin-d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">M(2)23AB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">M(2)LS1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGF-b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGF-beta</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGFbeta</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tegula</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tgfbeta</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">blink</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">blk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bone morphogenetic protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bone morphogenic protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">decapentaplegic</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">heldout</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ho</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)10638</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)22Fa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)k17036</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shortvein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shv</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dpp</rdfs:label>
+        <oboInOwl:hasExactSynonym>BMP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bmp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG9885</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DPP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DPP-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Decapentaplegic</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Decapentaplegic/Bone Morphogenetic Protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-DPP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmDPP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dpp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dpp/TGFbeta</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Haplo-insufficient</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hin-d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>M(2)23AB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>M(2)LS1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TGF-b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TGF-beta</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TGFbeta</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tegula</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tgfbeta</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>blink</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>blk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bone morphogenetic protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bone morphogenic protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>decapentaplegic</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>heldout</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ho</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)10638</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)22Fa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)k17036</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>shortvein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>shv</oboInOwl:hasExactSynonym>
+        <rdfs:label>dpp</rdfs:label>
     </owl:Class>
     
 
@@ -261,37 +259,37 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000500">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:RH46857</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG18090</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSK I</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSK II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSK-0</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSK-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSK-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSK-I</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-SK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-SK-0</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-SK-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-SK-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DrmSK-I</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DrmSK-II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosophila sulfakinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drososulfakinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosulfakinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosulfakinin 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosulfakinin 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SK-0</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sulfakinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cholecystokinin-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drosulfakinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drosulfakinins</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dsk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sulfakinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sulfakinin-0</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dsk</rdfs:label>
+        <oboInOwl:hasExactSynonym>BcDNA:RH46857</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG18090</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSK I</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSK II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSK-0</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSK-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSK-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSK-I</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-SK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-SK-0</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-SK-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-SK-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DrmSK-I</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DrmSK-II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosophila sulfakinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drososulfakinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosulfakinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosulfakinin 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosulfakinin 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SK-0</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sulfakinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cholecystokinin-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drosulfakinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drosulfakinins</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dsk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sulfakinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sulfakinin-0</oboInOwl:hasExactSynonym>
+        <rdfs:label>Dsk</rdfs:label>
     </owl:Class>
     
 
@@ -300,22 +298,22 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000504">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11094</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSX</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSXF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSXM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmdsx</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Doublesex</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dsx</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hermaphrodite</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">double sex</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">doublesex</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dsxF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dsxM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intersex-62c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ix-62c</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dsx</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG11094</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSX</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSXF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSXM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmdsx</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Doublesex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dsx</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hermaphrodite</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>double sex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>doublesex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dsxF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dsxM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>intersex-62c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ix-62c</oboInOwl:hasExactSynonym>
+        <rdfs:label>dsx</rdfs:label>
     </owl:Class>
     
 
@@ -324,50 +322,50 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000546">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1765</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8347</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DEcR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dhr23</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmEcR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ECR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ECR-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcR-A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcR-B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcR-B1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcR1b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcRA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcRB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcRB-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcRB1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcRC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcdR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ecdyson Receptor 1b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ecdysone Receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ecdysone receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ecdysone-R</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ecr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ecr1B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcrB1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NR1H1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">USP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Usp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0229075.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dECR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dmEcR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ecdysone receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ecdysone receptor complex</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ecdysone-Receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ecdysteroid receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ecdysterone receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ecr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lie</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long island expressway</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male sterile(2)42A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ms(2)06410</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ms(2)42A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snaggletooth</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snt</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EcR</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG1765</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG8347</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DEcR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dhr23</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmEcR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ECR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ECR-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcR-A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcR-B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcR-B1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcR1b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcRA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcRB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcRB-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcRB1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcRC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcdR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ecdyson Receptor 1b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ecdysone Receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ecdysone receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ecdysone-R</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ecr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ecr1B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EcrB1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NR1H1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>USP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Usp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0229075.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dECR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dmEcR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ecdysone receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ecdysone receptor complex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ecdysone-Receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ecdysteroid receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ecdysterone receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ecr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lie</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>long island expressway</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>male sterile(2)42A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ms(2)06410</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ms(2)42A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>snaggletooth</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>snt</oboInOwl:hasExactSynonym>
+        <rdfs:label>EcR</rdfs:label>
     </owl:Class>
     
 
@@ -376,15 +374,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000564">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5400</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DMEHAB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-EH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHAB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eclosion hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eclosion hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eh</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eh</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG5400</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DMEHAB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-EH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EHAB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Eclosion hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>eclosion hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>eh</oboInOwl:hasExactSynonym>
+        <rdfs:label>Eh</rdfs:label>
     </owl:Class>
     
 
@@ -393,31 +391,31 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000577">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">153867_at</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apigmented abdomen</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG9015</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EN</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ENGRAILED</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">En</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EnR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eng</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Engr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Engrailed</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Engrailed/Invected</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erased</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Es</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Invected</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">V</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">en1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">engrailed</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spa2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sparse SGPs 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spermatheca</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transcript group V</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vasodilator-stimulated phosphoprotein</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">en</rdfs:label>
+        <oboInOwl:hasExactSynonym>153867_at</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Apa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Apigmented abdomen</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG9015</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EN</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ENGRAILED</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>En</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EnR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Eng</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Engr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Engrailed</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Engrailed/Invected</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Erased</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Es</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Invected</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>V</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>en1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>engrailed</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spa2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sparse SGPs 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spermatheca</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>transcript group V</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>vasodilator-stimulated phosphoprotein</oboInOwl:hasExactSynonym>
+        <rdfs:label>en</rdfs:label>
     </owl:Class>
     
 
@@ -426,45 +424,45 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000606">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">10.5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">10.9</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">14.10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">20.35</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG2328</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Complementation group F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-eve</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E(eve)</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EVE</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EVEN-SKIPPED</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eve</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Even</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Even Skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Even skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Even-Skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Even-skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Evenskipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Group V</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Group VI</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">V</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VI</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dm-eve</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eve PRE/TRE element</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eve2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">even</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">even skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">even-skiped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">even-skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">evenskip</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">evenskipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)46CFg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)46CFh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)46CFj</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)46CFp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)46Ce</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)46Cg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lethal(2)46Ce</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eve</rdfs:label>
+        <oboInOwl:hasExactSynonym>10.5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>10.9</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>14.10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>20.35</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG2328</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Complementation group F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-eve</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>E(eve)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EVE</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EVEN-SKIPPED</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Eve</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Even</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Even Skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Even skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Even-Skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Even-skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Evenskipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Group V</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Group VI</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>V</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>VI</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dm-eve</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>eve PRE/TRE element</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>eve2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>even</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>even skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>even-skiped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>even-skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>evenskip</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>evenskipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)46CFg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)46CFh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)46CFj</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)46CFp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)46Ce</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)46Cg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lethal(2)46Ce</oboInOwl:hasExactSynonym>
+        <rdfs:label>eve</rdfs:label>
     </owl:Class>
     
 
@@ -473,41 +471,41 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000636">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5803</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAS III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAS3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FASIII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fas</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fas III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fas-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fas-III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FasIII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FascIII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fascicilin III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fasciclin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fasciclin 3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fasciclin III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fasciclin-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fasciclin-III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fasciclin3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FasciclinIII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fascilin III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fasiciclin III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fasicilin III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fasiclin III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FsciclinIII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fas III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fas-III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fas3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fasIII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fascIII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fasciclin 3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fasciclin III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fasciclin3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fasciclinIII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fascilin III</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fasiclin III</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fas3</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG5803</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FAS III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FAS3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FASIII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fas</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fas III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fas-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fas-III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FasIII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FascIII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fascicilin III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fasciclin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fasciclin 3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fasciclin III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fasciclin-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fasciclin-III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fasciclin3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FasciclinIII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fascilin III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fasiciclin III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fasicilin III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fasiclin III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FsciclinIII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fas III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fas-III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fas3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fasIII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fascIII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fasciclin 3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fasciclin III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fasciclin3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fasciclinIII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fascilin III</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fasiclin III</oboInOwl:hasExactSynonym>
+        <rdfs:label>Fas3</rdfs:label>
     </owl:Class>
     
 
@@ -516,24 +514,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0000964">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10034</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DM13</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmaf</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PL3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TJ</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tj</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Traffic Jam</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Traffic jam</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Traffic-Jam</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Traffic-jam</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female sterile(2)eo2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(2)eo-B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(2)eo2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(2)eoPL3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maf-L</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maf1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">traffic jam</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tj</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG10034</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DM13</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmaf</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PL3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TJ</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tj</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Traffic Jam</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Traffic jam</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Traffic-Jam</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Traffic-jam</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>female sterile(2)eo2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(2)eo-B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(2)eo2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(2)eoPL3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>maf-L</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>maf1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>traffic jam</oboInOwl:hasExactSynonym>
+        <rdfs:label>tj</rdfs:label>
     </owl:Class>
     
 
@@ -542,27 +540,27 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0001235">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1323/07</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1422/04</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17117</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-HTH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gene II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HTH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Homothorax</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hth</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MEIS1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Meis1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P53</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-EST:Liang-2.13</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clone 2.13</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dorsotonals</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dtl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">homothorax</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hth1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hth2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)05745</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)86Ca</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hth</rdfs:label>
+        <oboInOwl:hasExactSynonym>1323/07</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1422/04</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17117</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-HTH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gene II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>HTH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Homothorax</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hth</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MEIS1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Meis1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>P53</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-EST:Liang-2.13</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>clone 2.13</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dorsotonals</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dtl</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>homothorax</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hth1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hth2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)05745</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)86Ca</oboInOwl:hasExactSynonym>
+        <rdfs:label>hth</rdfs:label>
     </owl:Class>
     
 
@@ -571,24 +569,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0001257">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15009</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT34862</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ecdysone-inducible gene L2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GH28</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IMP-L2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IMPL2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Imaginal morphogenesis protein-Late 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Imaginal morphogenesis protein-late 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Imp-12</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Imp-L2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ImpL-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Impl2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ecdysone-inducible gene L2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">imaginal morphogenesis protein-late 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">imp-L2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">impL2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">neural and ectodermal development factor</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ImpL2</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG15009</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT34862</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ecdysone-inducible gene L2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GH28</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IMP-L2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IMPL2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Imaginal morphogenesis protein-Late 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Imaginal morphogenesis protein-late 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Imp-12</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Imp-L2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ImpL-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Impl2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ecdysone-inducible gene L2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>imaginal morphogenesis protein-late 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>imp-L2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>impL2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>neural and ectodermal development factor</oboInOwl:hasExactSynonym>
+        <rdfs:label>ImpL2</rdfs:label>
     </owl:Class>
     
 
@@ -597,32 +595,32 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0001981">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4B7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BG:DS07851.7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3758</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D.m.Escargot</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Escargot</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Esg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Esgargot</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fusion-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">br43</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dgl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">double glazed</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">escargot</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">esgargot</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fleabag</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">flg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)07082</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)35Ce</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)4B7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)br43</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)esg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l35Ce</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shof</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shut off</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wiz</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wizard</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">esg</rdfs:label>
+        <oboInOwl:hasExactSynonym>4B7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BG:DS07851.7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3758</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D.m.Escargot</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Escargot</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Esg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Esgargot</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fusion-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>br43</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dgl</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>double glazed</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>escargot</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>esgargot</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fleabag</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>flg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)07082</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)35Ce</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)4B7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)br43</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)esg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l35Ce</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>shof</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>shut off</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>wiz</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>wizard</oboInOwl:hasExactSynonym>
+        <rdfs:label>esg</rdfs:label>
     </owl:Class>
     
 
@@ -631,24 +629,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0002522">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BG:DS00004.9</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1264</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm lab</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmLab</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmlab</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EfR9</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">F121</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">F24</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">F90</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">F90-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LAB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lab</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Labial</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)01241</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)84Ac</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">labial</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lb</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lab</rdfs:label>
+        <oboInOwl:hasExactSynonym>BG:DS00004.9</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG1264</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm lab</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmLab</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmlab</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EfR9</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>F121</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>F24</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>F90</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>F90-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LAB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lab</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Labial</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)01241</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)84Ac</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>labial</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lb</oboInOwl:hasExactSynonym>
+        <rdfs:label>lab</rdfs:label>
     </owl:Class>
     
 
@@ -657,23 +655,23 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0002565">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C23</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11538</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6806</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmeLSP2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LHP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LSP 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LSP-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LSP2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Larval serum protein 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Larval serum protein-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lsp-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pt-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">larval serum protein 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">larval-hemolymph-protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lsp2</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lsp2</rdfs:label>
+        <oboInOwl:hasExactSynonym>C23</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG11538</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG6806</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmeLSP2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LHP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LSP 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LSP-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LSP2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Larval serum protein 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Larval serum protein-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lsp-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Protein-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pt-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>larval serum protein 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>larval-hemolymph-protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lsp2</oboInOwl:hasExactSynonym>
+        <rdfs:label>Lsp2</rdfs:label>
     </owl:Class>
     
 
@@ -682,17 +680,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0002576">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1689</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LZ</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lozenge</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lz</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amx</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(1)A1569</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(1)M69</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lozenge</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spe</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spectacled</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lz</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG1689</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LZ</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lozenge</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lz</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>amx</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(1)A1569</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(1)M69</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lozenge</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spe</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spectacled</oboInOwl:hasExactSynonym>
+        <rdfs:label>lz</rdfs:label>
     </owl:Class>
     
 
@@ -701,20 +699,20 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0002673">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BG:DS02740.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4965</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cdc25</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TWINE</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Twe</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Twine</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cdc25</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)35Fh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mat(2)syn-A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mat(2)synHB5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mat(2)syn[HB5]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">twine</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">twn</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">twe</rdfs:label>
+        <oboInOwl:hasExactSynonym>BG:DS02740.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG4965</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cdc25</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TWINE</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Twe</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Twine</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cdc25</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)35Fh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mat(2)syn-A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mat(2)synHB5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mat(2)syn[HB5]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>twine</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>twn</oboInOwl:hasExactSynonym>
+        <rdfs:label>twe</rdfs:label>
     </owl:Class>
     
 
@@ -723,21 +721,21 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0002985">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3851</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ODD</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ODD-SKIPPED</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odd</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odd Skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odd skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odd-Skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odd-skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)01863</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">odd paired</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">odd skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">odd-skipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oddskipped</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ods</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">odd</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG3851</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ODD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ODD-SKIPPED</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odd</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odd Skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odd skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odd-Skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odd-skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)01863</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>odd paired</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>odd skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>odd-skipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>oddskipped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ods</oboInOwl:hasExactSynonym>
+        <rdfs:label>odd</rdfs:label>
     </owl:Class>
     
 
@@ -746,26 +744,26 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003068">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG2647</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clock</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EG:155E2.4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PER</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PERIOD</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Per</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Per-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Period</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clk-6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clock-6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dPER</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dPer</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dmper</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dper</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dperiod</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mel_per</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">period</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">period clock protein</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">per</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG2647</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Clk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Clock</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EG:155E2.4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PER</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PERIOD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Per</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Per-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Period</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>clk-6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>clock-6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dPER</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dPer</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dmper</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dper</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dperiod</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mel_per</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>period</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>period clock protein</oboInOwl:hasExactSynonym>
+        <rdfs:label>per</rdfs:label>
     </owl:Class>
     
 
@@ -774,17 +772,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003249">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10888</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DMELRH3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm Rh3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RH3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin 3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rh3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhodopsin</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rh3</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG10888</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DMELRH3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm Rh3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RH3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin 3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>r3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rh3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rhodopsin</oboInOwl:hasExactSynonym>
+        <rdfs:label>Rh3</rdfs:label>
     </owl:Class>
     
 
@@ -793,18 +792,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003250">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG9668</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DMELRH4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm Rh4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RH4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin 4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rh4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhodopsin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhodopsin 4</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rh4</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG9668</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DMELRH4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm Rh4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RH4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin 4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>r4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rh4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rhodopsin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rhodopsin 4</oboInOwl:hasExactSynonym>
+        <rdfs:label>Rh4</rdfs:label>
     </owl:Class>
     
 
@@ -813,28 +813,28 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003255">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BG:DS00180.13</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8930</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT25644</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DLGR-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DLGR2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DLgr2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dlgr2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glycoprotein hormone receptor II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LGR2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lgr2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickets</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dLGR2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dlgr2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dlgr2/rk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glycoprotein hormone receptor II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glycoprotein-hormone-receptor-II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">leucine-rich repeat-containing G protein-coupled receptor 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lgr2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rickets</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rk/CG8930</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rk</rdfs:label>
+        <oboInOwl:hasExactSynonym>BG:DS00180.13</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG8930</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT25644</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DLGR-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DLGR2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DLgr2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dlgr2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Glycoprotein hormone receptor II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LGR2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lgr2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rickets</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dLGR2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dlgr2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dlgr2/rk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glycoprotein hormone receptor II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glycoprotein-hormone-receptor-II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>leucine-rich repeat-containing G protein-coupled receptor 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lgr2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rickets</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rk/CG8930</oboInOwl:hasExactSynonym>
+        <rdfs:label>rk</rdfs:label>
     </owl:Class>
     
 
@@ -843,20 +843,20 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003463">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG9224</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chordin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm sog</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SOG</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Short Gastrulation</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Short gastrulation</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sog</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)G0160</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)G0395</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)G0479</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short gastrulation</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short of gastrulation</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short-gastrulation</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sog</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG9224</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Chordin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm sog</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SOG</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Short Gastrulation</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Short gastrulation</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sog</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)G0160</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)G0395</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)G0479</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>short gastrulation</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>short of gastrulation</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>short-gastrulation</oboInOwl:hasExactSynonym>
+        <rdfs:label>sog</rdfs:label>
     </owl:Class>
     
 
@@ -865,28 +865,28 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003507">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A-box-binding factor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A7.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ABF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Abf</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3992</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGATAb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GATA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GATAb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SERPENT</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SRP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Serpent</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Srp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abf</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dGATAb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)01549</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)89B2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)neo45</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">serpent</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">serpentD</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">srpD</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">srp</rdfs:label>
+        <oboInOwl:hasExactSynonym>A-box-binding factor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>A7.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ABF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Abf</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3992</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGATAb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GATA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GATAb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SERPENT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SRP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Serpent</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Srp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>abf</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dGATAb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)01549</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)89B2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)neo45</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>serpent</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>serpentD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>srpD</oboInOwl:hasExactSynonym>
+        <rdfs:label>srp</rdfs:label>
     </owl:Class>
     
 
@@ -895,41 +895,41 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003651">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0005/12</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0042/01</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0106/18</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0114/20</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0351/01</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0598/01</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0861/07</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:GH08189</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11502</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG18158</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NR2F3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SEVEN-UP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SVP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SVP-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SVP1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Seven Up</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Seven up</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Seven-Up</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Seven-up</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sevenup</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Svp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ck16</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complementation group 7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">don</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">down-and-out</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)07842</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)87Bd</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)ck16</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)j2E2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)rA028</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)rL069</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">seven up</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">seven-up</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sevenup</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">svp</rdfs:label>
+        <oboInOwl:hasExactSynonym>0005/12</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0042/01</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0106/18</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0114/20</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0351/01</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0598/01</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0861/07</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BcDNA:GH08189</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG11502</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG18158</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NR2F3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SEVEN-UP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SVP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SVP-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SVP1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Seven Up</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Seven up</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Seven-Up</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Seven-up</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sevenup</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Svp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ck16</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>complementation group 7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>don</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>down-and-out</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)07842</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)87Bd</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)ck16</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)j2E2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)rA028</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)rL069</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>seven up</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>seven-up</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sevenup</oboInOwl:hasExactSynonym>
+        <rdfs:label>svp</rdfs:label>
     </owl:Class>
     
 
@@ -938,25 +938,25 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003747">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15779</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmel5a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR5A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR5a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRLU.7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr5A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GrLU7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 5a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor LU.7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LU.7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tre</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trehalose sensitivity</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trehalose-sensitivity</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gustatory receptor 5a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">han</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tre</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trehalose receptor</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr5a</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG15779</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmel5a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR5A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR5a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GRLU.7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr5A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GrLU7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 5a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor LU.7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LU.7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tre</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Trehalose sensitivity</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Trehalose-sensitivity</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gustatory receptor 5a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>han</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tre</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>trehalose receptor</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr5a</rdfs:label>
     </owl:Class>
     
 
@@ -965,19 +965,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003866">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1374</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T shirt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-shirt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TSH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Teashirt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tsh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ae</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ae[l]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aeroplane</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)04319</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)B4-2-12</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">teashirt</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tsh</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG1374</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>T shirt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>T-shirt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TSH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Teashirt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tsh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ae</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ae[l]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>aeroplane</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)04319</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)B4-2-12</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>teashirt</oboInOwl:hasExactSynonym>
+        <rdfs:label>tsh</rdfs:label>
     </owl:Class>
     
 
@@ -986,18 +986,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003961">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7171</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm UO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OU</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UOX</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">URO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Uo</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Urate oxidase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0140519.210</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">urate oxidase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uro</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Uro</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG7171</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm UO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OU</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>UO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>UOX</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>URO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Uo</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Urate oxidase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0140519.210</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>urate oxidase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>uro</oboInOwl:hasExactSynonym>
+        <rdfs:label>Uro</rdfs:label>
     </owl:Class>
     
 
@@ -1006,15 +1006,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0003975">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3830</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VG</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vestgial</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vestigial</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestigal</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestigial</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vg21</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vg</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG3830</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>VG</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Vestgial</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Vestigial</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Vg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>vestigal</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>vestigial</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>vg21</oboInOwl:hasExactSynonym>
+        <rdfs:label>vg</rdfs:label>
     </owl:Class>
     
 
@@ -1023,24 +1023,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004102">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12154</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ocelliless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orthodenticle</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Otd</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Otx</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)7Ff</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)8Ac</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oc2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ocelliless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ort</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">orthodentical</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">orthodenticle</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">otd</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uvi</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uvi-insensitive</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oc</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG12154</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Oc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ocelliless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Orthodenticle</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Otd</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Otx</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)7Ff</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)8Ac</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>oc2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ocelliless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ort</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>orthodentical</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>orthodenticle</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>otd</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>uvi</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>uvi-insensitive</oboInOwl:hasExactSynonym>
+        <rdfs:label>oc</rdfs:label>
     </owl:Class>
     
 
@@ -1049,19 +1049,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004198">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:GH10590</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11387</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CUT</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ct</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cut</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cut</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kf</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kinked-femur</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)7Ba</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)7Bb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)VE614</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ct</rdfs:label>
+        <oboInOwl:hasExactSynonym>BcDNA:GH10590</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG11387</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CUT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ct</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cut</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cut</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>kf</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>kinked-femur</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)7Ba</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)7Bb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)VE614</oboInOwl:hasExactSynonym>
+        <rdfs:label>ct</rdfs:label>
     </owl:Class>
     
 
@@ -1070,11 +1070,11 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004228">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7936</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MEX</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Midgut expression 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">midgut expression 1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mex1</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG7936</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MEX</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Midgut expression 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>midgut expression 1</oboInOwl:hasExactSynonym>
+        <rdfs:label>mex1</rdfs:label>
     </owl:Class>
     
 
@@ -1083,23 +1083,23 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004552">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADKH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AKH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AKH1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adipokinetic Hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adipokinetic hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adipokinetic hormone-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1171</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-AKH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DrmAKH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hrth</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypertrehaloseaemic-hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adipo- kinetic hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adipokinetic hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">akh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dAKH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dAkh</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Akh</rdfs:label>
+        <oboInOwl:hasExactSynonym>ADKH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AKH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AKH1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Adipokinetic Hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Adipokinetic hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Adipokinetic hormone-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG1171</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-AKH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DrmAKH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hrth</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hypertrehaloseaemic-hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>adipo- kinetic hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>adipokinetic hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>akh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dAKH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dAkh</oboInOwl:hasExactSynonym>
+        <rdfs:label>Akh</rdfs:label>
     </owl:Class>
     
 
@@ -1108,50 +1108,50 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004595">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0244/09</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0320/10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0441/16</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0451/09</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0563/18</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0585/13</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0664/07</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0671/02</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0763/13</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0989/01</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1135/07</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1135/09</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1167/13</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1316/02</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">671/2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:HL08040</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17228</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DMPROSPER</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DROPROSA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PROS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PROS-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PROS-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pro</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pros</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prosp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prospero</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Voila</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a la voile et a la vapeur</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0140519.15</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)10419</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)j12C8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)j6E2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)rH013</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)rI160</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)rJ806</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)rK137</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)rK204</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)rL433</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)rO534</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pro</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prosp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prospero</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">voila</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pros</rdfs:label>
+        <oboInOwl:hasExactSynonym>0244/09</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0320/10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0441/16</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0451/09</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0563/18</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0585/13</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0664/07</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0671/02</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0763/13</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0989/01</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1135/07</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1135/09</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1167/13</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1316/02</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>671/2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BcDNA:HL08040</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17228</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DMPROSPER</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DROPROSA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PROS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PROS-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PROS-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pro</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pros</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Prosp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Prospero</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Voila</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>a la voile et a la vapeur</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0140519.15</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)10419</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)j12C8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)j6E2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)rH013</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)rI160</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)rJ806</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)rK137</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)rK204</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)rL433</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)rO534</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pro</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>prosp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>prospero</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>voila</oboInOwl:hasExactSynonym>
+        <rdfs:label>pros</rdfs:label>
     </owl:Class>
     
 
@@ -1160,28 +1160,28 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004606">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1322</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZFH-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZFH1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZFh1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zfh-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zfh1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zfh1a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zinc Finger Homeodomain 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zinc-finger homeodomain protein 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zn finger homeodomain 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zn homeodomain 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)00865</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zfh-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zfl-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zhf1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zinc finger homeodomain 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zinc finger homeodomain protein-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zinc finger homeodomain-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zinc-finger homeobox gene</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zinc-finger homeodomain protein 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zinc-finger homeodomain1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zfh1</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG1322</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ZFH-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ZFH1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ZFh1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zfh-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zfh1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zfh1a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zinc Finger Homeodomain 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zinc-finger homeodomain protein 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zn finger homeodomain 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zn homeodomain 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)00865</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>zfh-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>zfl-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>zhf1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>zinc finger homeodomain 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>zinc finger homeodomain protein-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>zinc finger homeodomain-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>zinc-finger homeobox gene</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>zinc-finger homeodomain protein 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>zinc-finger homeodomain1</oboInOwl:hasExactSynonym>
+        <rdfs:label>zfh1</rdfs:label>
     </owl:Class>
     
 
@@ -1190,23 +1190,23 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004618">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7672</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E(sina)5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enhancer of seven in absentia 5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GLASS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gla</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glass</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SS3-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SY3-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Suppressor of GMR-sina 3-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gla</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glass</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">no-ocelli--narrow-eyes</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">none</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rauhig</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rh</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gl</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG7672</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>E(sina)5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Enhancer of seven in absentia 5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GLASS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gl</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gla</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Glass</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SS3-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SY3-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Suppressor of GMR-sina 3-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gla</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glass</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>no-ocelli--narrow-eyes</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>none</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rauhig</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rh</oboInOwl:hasExactSynonym>
+        <rdfs:label>gl</rdfs:label>
     </owl:Class>
     
 
@@ -1215,31 +1215,31 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004644">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4637</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmhh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hedgehog</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hedghog</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mir</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mirabile</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Moonrat</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mrt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PKC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0134654.19</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0182946.19</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atypical</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bar</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bar-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bar-on-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bar3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hedgehog</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)hh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)neo56</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)neo57</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hh</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG4637</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmhh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>HH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hedgehog</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hedghog</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mir</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mirabile</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Moonrat</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mrt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PKC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0134654.19</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0182946.19</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>atypical</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bar</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bar-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bar-on-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bar3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hedgehog</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)hh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)neo56</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)neo57</oboInOwl:hasExactSynonym>
+        <rdfs:label>hh</rdfs:label>
     </owl:Class>
     
 
@@ -1248,32 +1248,32 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004652">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTB-VI</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTB-protein-VI</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BtbVI</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14307</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7688</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7689</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7690</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT22773</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmfru</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FRU</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FRU-PI</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fru</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FruM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fruitless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cg7688</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cg7689</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fru-satori</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fruC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fruitless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fruity</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fry</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fty</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ms(3)06411</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sat</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">satori</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fru</rdfs:label>
+        <oboInOwl:hasExactSynonym>BTB-VI</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BTB-protein-VI</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BtbVI</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14307</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG7688</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG7689</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG7690</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT22773</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmfru</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FRU</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FRU-PI</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fru</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FruM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fruitless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cg7688</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cg7689</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fru-satori</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fruC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fruitless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fruity</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fry</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fty</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ms(3)06411</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sat</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>satori</oboInOwl:hasExactSynonym>
+        <rdfs:label>fru</rdfs:label>
     </owl:Class>
     
 
@@ -1282,37 +1282,37 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004666">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0483/09</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0716/08</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0899/14</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0953/08</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1002/10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1034/02</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1050/13</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1110/04</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1111/10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1330/08</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1479/04</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7771</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">S8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sim</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Single minded</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Single-minded</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Singled-minded</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bHLHe16</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)87Ea</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)E320</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)RD</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)S8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)s8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">schmal</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">single minded</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">single-minded</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">singleminded</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sim</rdfs:label>
+        <oboInOwl:hasExactSynonym>0483/09</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0716/08</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0899/14</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>0953/08</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1002/10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1034/02</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1050/13</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1110/04</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1111/10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1330/08</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1479/04</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG7771</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>S8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SIM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sim</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Single minded</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Single-minded</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Singled-minded</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bHLHe16</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)87Ea</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)E320</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)RD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)S8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)s8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>schm</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>schmal</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>shm</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>single minded</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>single-minded</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>singleminded</oboInOwl:hasExactSynonym>
+        <rdfs:label>sim</rdfs:label>
     </owl:Class>
     
 
@@ -1321,40 +1321,40 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0004956">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5993</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Os</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Outstretched</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UPD</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UPD1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Unpaired</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Unpaired 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Unpaired/Out-stretched</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Unpaireds</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Upd</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Upd1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)YC43</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)YM55</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">od</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">odsy</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">os</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">outstretched</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">outstretched small eye</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">outstretched-smalleye</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sis-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sis-c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sisC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sisterless c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">small-eye</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sy</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unpaired</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unpaired 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unpaired1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upd</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upd homolog</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upd1</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG5993</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Os</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Outstretched</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>UPD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>UPD1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Unpaired</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Unpaired 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Unpaired/Out-stretched</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Unpaireds</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Upd</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Upd1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)YC43</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)YM55</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>od</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>odsy</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>os</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>outstretched</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>outstretched small eye</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>outstretched-smalleye</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sis-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sis-c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sisC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sisterless c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>small-eye</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sy</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>unp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>unpaired</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>unpaired 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>unpaired1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>upa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>upd</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>upd homolog</oboInOwl:hasExactSynonym>
+        <rdfs:label>upd1</rdfs:label>
     </owl:Class>
     
 
@@ -1363,24 +1363,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0005638">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C/EBP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCAAT/enhancer binding protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4354</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DC/EBP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DM8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-c/EBP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmC/EBP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SLBO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Slbo</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Slow Border Cells</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Slow border cells</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(2)7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(2)8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(2)ry7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(2)ry8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">slobo</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">slow border cells</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">slbo</rdfs:label>
+        <oboInOwl:hasExactSynonym>C/EBP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCAAT/enhancer binding protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG4354</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DC/EBP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DM8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-c/EBP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmC/EBP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SLBO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Slbo</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Slow Border Cells</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Slow border cells</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(2)7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(2)8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(2)ry7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(2)ry8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>slobo</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>slow border cells</oboInOwl:hasExactSynonym>
+        <rdfs:label>slbo</rdfs:label>
     </owl:Class>
     
 
@@ -1389,26 +1389,26 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0005677">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BG:DS02780.3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4952</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DACHSHUND</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dac</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dac2-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dach</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dachshund</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dachsund</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-DAC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dach</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dachshund</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dachsund</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dacshund</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">daschund</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)36Ae</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)rK364</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spinosus</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spn</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dac</rdfs:label>
+        <oboInOwl:hasExactSynonym>BG:DS02780.3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG4952</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DAC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DACHSHUND</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dac</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dac2-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dach</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dachshund</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dachsund</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-DAC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dach</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dachshund</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dachsund</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dacshund</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>daschund</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)36Ae</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)rK364</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spinosus</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spn</oboInOwl:hasExactSynonym>
+        <rdfs:label>dac</rdfs:label>
     </owl:Class>
     
 
@@ -1417,17 +1417,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0005775">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7503</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CON</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT1840</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Connectin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ubx-t35</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-64C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">con</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conn</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">connectin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transcript-35</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Con</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG7503</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CON</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT1840</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Connectin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ubx-t35</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-64C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>con</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>conn</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>connectin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>transcript-35</oboInOwl:hasExactSynonym>
+        <rdfs:label>Con</rdfs:label>
     </owl:Class>
     
 
@@ -1436,17 +1436,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0010109">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">44C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8704</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DPN</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dead-pan</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Deadpan</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dpn</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-EST:fe1B12</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-fast-evolving-1B12</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bHLHe50</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">deadpan</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dpn</rdfs:label>
+        <oboInOwl:hasExactSynonym>44C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG8704</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DPN</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dead-pan</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Deadpan</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dpn</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-EST:fe1B12</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-fast-evolving-1B12</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bHLHe50</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>deadpan</oboInOwl:hasExactSynonym>
+        <rdfs:label>dpn</rdfs:label>
     </owl:Class>
     
 
@@ -1455,45 +1455,46 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0010226">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8938</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGST-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGST2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGSTS1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGSTS1-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGst-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGstS1-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Est2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GST</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GST S1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GST-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GST-S1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GST2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GSTII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GSTS1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GSTs</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glutathione S transferase 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glutathione S transferase S1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glutathione S-transferase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glutathione S-transferase 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glutathione S-transferase S1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glutathione-S-Transferase 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gst2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GstS1-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">S1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dHPGDS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glutathione S-transferase-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glutathione S-transferase-S1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glutathione transferase-related protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glutathione-S-transferase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glutathione-S-transferase (GST) S1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gst</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gstD2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gsts1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)04227</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)k08805</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lincRNA.330</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">n(2)06253</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GstS1</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG8938</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGST-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGST2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGSTS1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGSTS1-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGst-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGstS1-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Est2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GST</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GST S1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GST-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GST-S1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GST2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GSTII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GSTS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GSTS1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GSTs</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Glutathione S transferase 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Glutathione S transferase S1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Glutathione S-transferase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Glutathione S-transferase 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Glutathione S-transferase S1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Glutathione-S-Transferase 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gst2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GstS1-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>S1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dHPGDS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glutathione S-transferase-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glutathione S-transferase-S1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glutathione transferase-related protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glutathione-S-transferase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glutathione-S-transferase (GST) S1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gst</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gstD2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gsts1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)04227</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)k08805</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lincRNA.330</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>n(2)06253</oboInOwl:hasExactSynonym>
+        <rdfs:label>GstS1</rdfs:label>
     </owl:Class>
     
 
@@ -1502,22 +1503,22 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0010397">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10119</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">G intermediate filament</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">G-IF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LAMC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lamin C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lamin-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LaminC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lamC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lamin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lamin A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lamin C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lamin DmC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">laminC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pG-IF</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LamC</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG10119</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>G intermediate filament</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>G-IF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LAMC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lamin C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lamin-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LaminC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lamC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lamin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lamin A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lamin C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lamin DmC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>laminC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pG-IF</oboInOwl:hasExactSynonym>
+        <rdfs:label>LamC</rdfs:label>
     </owl:Class>
     
 
@@ -1526,17 +1527,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0010433">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ATO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">At</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ato</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Atonal</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7508</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ato1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ato[Dm]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atona</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atonal</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bHLHa10</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ato</rdfs:label>
+        <oboInOwl:hasExactSynonym>ATO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>At</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ato</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Atonal</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG7508</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ato1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ato[Dm]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>atona</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>atonal</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bHLHa10</oboInOwl:hasExactSynonym>
+        <rdfs:label>ato</rdfs:label>
     </owl:Class>
     
 
@@ -1545,22 +1546,22 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0010453">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4698</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DWnt-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DWnt4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm DWnt4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dwnt-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dwnt4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WNT4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wnt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wnt oncogene analog 4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wnt-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-EST:Liang-2.4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clone 2.4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dWnt4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wnt-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wnt4</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wnt4</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG4698</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DWnt-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DWnt4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm DWnt4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dwnt-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dwnt4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>WNT4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Wnt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Wnt oncogene analog 4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Wnt-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-EST:Liang-2.4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>clone 2.4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dWnt4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>wnt-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>wnt4</oboInOwl:hasExactSynonym>
+        <rdfs:label>Wnt4</rdfs:label>
     </owl:Class>
     
 
@@ -1569,26 +1570,26 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0011581">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6440</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DMS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-MS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dms</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-MS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-myosuppressin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drome-MS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dromyosuppressin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FLRFa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MEMS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myosuppressin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nems</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neomyosuppressin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TDVDHVFLRFamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cg6440</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dms</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dromyosuppressin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myosuppressin</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ms</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG6440</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DMS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-MS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dms</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-MS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-myosuppressin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drome-MS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dromyosuppressin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FLRFa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MEMS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myosuppressin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Nems</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Neomyosuppressin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TDVDHVFLRFamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cg6440</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dms</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dromyosuppressin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myosuppressin</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ms</rdfs:label>
     </owl:Class>
     
 
@@ -1597,22 +1598,22 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0011701">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3702</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AbRK2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Antibody RK2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG31240</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8045(CT24072)</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT24072</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REPO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RK2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Repo</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reversed Polarity</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reversed polarity</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)03702</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reverse polarity</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reversed polarity</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rk2</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">repo</rdfs:label>
+        <oboInOwl:hasExactSynonym>3702</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AbRK2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Antibody RK2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG31240</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG8045(CT24072)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT24072</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>REPO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RK2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Repo</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Reversed Polarity</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Reversed polarity</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)03702</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>reverse polarity</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>reversed polarity</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rk2</oboInOwl:hasExactSynonym>
+        <rdfs:label>repo</rdfs:label>
     </owl:Class>
     
 
@@ -1621,27 +1622,27 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0011723">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bra</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brachyenteron</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brachyury</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Byn</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7260</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D-TRA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D-Trg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DTrg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-BYN</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T related antigen</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-related gene</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tra</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apro</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aproctous</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">brachyenteron</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">brachyury</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">byn/apro</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dm-Trg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trg</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">byn</rdfs:label>
+        <oboInOwl:hasExactSynonym>Bra</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Brachyenteron</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Brachyury</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Byn</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG7260</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D-TRA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D-Trg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DTrg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-BYN</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>T related antigen</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>T-related gene</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tra</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Trg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>apro</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>aproctous</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>brachyenteron</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>brachyury</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>byn/apro</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dm-Trg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>trg</oboInOwl:hasExactSynonym>
+        <rdfs:label>byn</rdfs:label>
     </owl:Class>
     
 
@@ -1650,24 +1651,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0012344">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8348</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CRF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CRF-like diuretic hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CRF-like peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH 44</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH-44</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH44</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH[[44]]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diuretic hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diuretic hormone 44</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-DH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drome-DH[[44]]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diuretic hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diuretic hormone 44</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drome-DH44</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dh44</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG8348</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CRF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CRF-like diuretic hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CRF-like peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH 44</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH-44</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH44</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH[[44]]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Diuretic hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Diuretic hormone 44</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-DH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drome-DH[[44]]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>diuretic hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>diuretic hormone 44</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drome-DH44</oboInOwl:hasExactSynonym>
+        <rdfs:label>Dh44</rdfs:label>
     </owl:Class>
     
 
@@ -1676,14 +1677,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0013323">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13687</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTTH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prothoracicotropic hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prothoracicotopic hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prothoracicotropic hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ptth</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ptth</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG13687</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PTTH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Prothoracicotropic hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>prothoracicotopic hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>prothoracicotropic hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ptth</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ptth</rdfs:label>
     </owl:Class>
     
 
@@ -1692,16 +1692,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0013469">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12296</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KLU</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Klu</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Klumpfuss</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P09036</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">klumpfuss</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">klumphuss</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)09036</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)10052</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">klu</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG12296</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>KLU</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Klu</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Klumpfuss</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>P09036</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>klumpfuss</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>klumphuss</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)09036</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)10052</oboInOwl:hasExactSynonym>
+        <rdfs:label>klu</rdfs:label>
     </owl:Class>
     
 
@@ -1710,19 +1710,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0013767">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3302</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CORZ</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CRZ</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cora</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corazonin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-Crz</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-COR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">corazonin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crz</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">preprocorazonin</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crz</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG3302</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>COR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CORZ</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CRZ</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cora</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Corazonin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-Crz</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-COR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>corazonin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>crz</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>preprocorazonin</oboInOwl:hasExactSynonym>
+        <rdfs:label>Crz</rdfs:label>
     </owl:Class>
     
 
@@ -1731,19 +1731,20 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0014019">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5279</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DMELRH5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm Rh5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RH5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin 5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rh5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhodopsin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhodopsin 5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhodopsin-5</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rh5</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG5279</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DMELRH5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm Rh5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RH5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin 5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>r5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rh5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rhodopsin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rhodopsin 5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rhodopsin-5</oboInOwl:hasExactSynonym>
+        <rdfs:label>Rh5</rdfs:label>
     </owl:Class>
     
 
@@ -1752,23 +1753,23 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0014163">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4609</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAX</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Failed Axonal Connections</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Failed axon connections</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fax</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-EST:Liang-1.34</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0172774.62</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0172774.63</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0172774.65</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0172774.66</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0172774.67</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0172774.68</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0172774.69</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clone 1.34</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fac</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">failed axon connections</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fax</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG4609</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FAX</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Failed Axonal Connections</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Failed axon connections</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fax</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-EST:Liang-1.34</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0172774.62</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0172774.63</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0172774.65</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0172774.66</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0172774.67</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0172774.68</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0172774.69</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>clone 1.34</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fac</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>failed axon connections</oboInOwl:hasExactSynonym>
+        <rdfs:label>fax</rdfs:label>
     </owl:Class>
     
 
@@ -1777,24 +1778,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0014179">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12245</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCM1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GCMa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gcm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">N7-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glia cells missing</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glial cell deficient</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glial cell missing</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glial cells missing</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glial cells-missing</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glide glide2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glide/gcm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)N7-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ucc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upper class chordotonals</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gcm</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG12245</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GCM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GCM1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GCMa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gcm</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>N7-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glia cells missing</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glial cell deficient</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glial cell missing</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glial cells missing</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glial cells-missing</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glide glide2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glide/gcm</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)N7-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ucc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>upper class chordotonals</oboInOwl:hasExactSynonym>
+        <rdfs:label>gcm</rdfs:label>
     </owl:Class>
     
 
@@ -1803,39 +1804,39 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0014343">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10601</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">De1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">De3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Group F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IRO-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Iro</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Iro-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IroC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Iroquis complex</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Iroquois</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIRR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mirr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mirror</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mrr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sai</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sail</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">caupalican</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cre</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crep</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crepuscule</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">group F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iro</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iro-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iroquois</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)69Ca</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)69Da</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)6D1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)A5-3-42</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mir</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mirror</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mrr</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mirr</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG10601</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>De1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>De3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Group F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IRO-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Iro</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Iro-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IroC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Iroquis complex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Iroquois</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIRR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mirr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mirror</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mrr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sai</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sail</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>caupalican</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cre</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>crep</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>crepuscule</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>group F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>iro</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>iro-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>iroquois</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)69Ca</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)69Da</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)6D1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)A5-3-42</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mir</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mirror</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mrr</oboInOwl:hasExactSynonym>
+        <rdfs:label>mirr</rdfs:label>
     </owl:Class>
     
 
@@ -1844,26 +1845,26 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0014396">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bruchpilot</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3234</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ritsu</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TIM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TIMELESS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tim</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tim-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Timeless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dTIM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dTim</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dtim</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dtimeless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mel_tim</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rit</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ritsu</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">s-tim</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tim1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">timeless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">timeless1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tim</rdfs:label>
+        <oboInOwl:hasExactSynonym>Bruchpilot</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3234</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ritsu</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TIM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TIMELESS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tim</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tim-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Timeless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dTIM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dTim</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dtim</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dtimeless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mel_tim</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rit</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ritsu</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>s-tim</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tim1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>timeless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>timeless1</oboInOwl:hasExactSynonym>
+        <rdfs:label>tim</rdfs:label>
     </owl:Class>
     
 
@@ -1872,18 +1873,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0015380">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10758</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17348</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DRL</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Derailed</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">derailed</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linotte</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lio</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lio/drl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lionette</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drl</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG10758</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17348</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DRL</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Derailed</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drl</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>derailed</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>linotte</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lio</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lio/drl</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lionette</oboInOwl:hasExactSynonym>
+        <rdfs:label>drl</rdfs:label>
     </owl:Class>
     
 
@@ -1892,60 +1893,60 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0015591">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ALLS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AST</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AST-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AST-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AST-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AST-A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin A2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin A3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin A4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin Diploptera-type</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ast</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ast-A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstA-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstA-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstA-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstA-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstA2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstA4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:RE16553</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13633</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAP-A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DST-1A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DST-2A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DST-3A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DST-4A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-AST-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-AST-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-AST-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-AST-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-AST-A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drostatin-A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drostatin-A2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drostatin-A3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drostatin-A4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FGLa-type allatostatin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin A-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin-A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin-A-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin-A4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ast</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drostatin-A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drostatin-A2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drostatin-A3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drostatin-A4</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstA</rdfs:label>
+        <oboInOwl:hasExactSynonym>ALLS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ASA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AST</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AST-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AST-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AST-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AST-A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin A2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin A3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin A4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin Diploptera-type</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ast</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ast-A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstA-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstA-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstA-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstA-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstA2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstA4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BcDNA:RE16553</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13633</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DAP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DAP-A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DST-1A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DST-2A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DST-3A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DST-4A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-AST-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-AST-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-AST-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-AST-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-AST-A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drostatin-A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drostatin-A2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drostatin-A3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drostatin-A4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FGLa-type allatostatin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin A-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin-A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin-A-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin-A4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ast</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drostatin-A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drostatin-A2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drostatin-A3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drostatin-A4</oboInOwl:hasExactSynonym>
+        <rdfs:label>AstA</rdfs:label>
     </owl:Class>
     
 
@@ -1954,21 +1955,22 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0019940">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5192</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DMELRH6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm Rh6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R8 rhodopsin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RH6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin 6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rh6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhodopsin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhodopsin 6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhodopsin-6</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rh6</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG5192</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DMELRH6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm Rh6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>R8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>R8 rhodopsin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RH6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin 6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>r8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rh6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rhodopsin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rhodopsin 6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rhodopsin-6</oboInOwl:hasExactSynonym>
+        <rdfs:label>Rh6</rdfs:label>
     </owl:Class>
     
 
@@ -1977,25 +1979,25 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0020258">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BG:DS06238.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3478</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drifter</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPK1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pickpocket</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pickpocket1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ppk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dfr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dmdNaC1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dmdNaCl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mdNaC1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">multidendritic neurons sodium channel 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pickpocket</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pickpocket 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pickpocket1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pkt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ppk1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ppk</rdfs:label>
+        <oboInOwl:hasExactSynonym>BG:DS06238.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3478</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drifter</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPK1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pickpocket</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pickpocket1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ppk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dfr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dmdNaC1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dmdNaCl</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mdNaC1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>multidendritic neurons sodium channel 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pickpocket</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pickpocket 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pickpocket1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pkt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ppk1</oboInOwl:hasExactSynonym>
+        <rdfs:label>ppk</rdfs:label>
     </owl:Class>
     
 
@@ -2004,45 +2006,45 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0020299">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">0837/10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG18485</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG31317</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3375</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dof</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dof/stumps/heartbroken</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Downstream of FGF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Downstream of FGF receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Downstream of FGFR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Downstream of FGFR/Heartbroken/Stumps</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Downstream-of-FGFR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hbr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hbr/Dof</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heartbroken</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P1740</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Stumps</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-EST:CL47</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-estC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dof</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dof/hbr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dof/hbr/sms</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dof1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">downstream of FGF receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">downstream of FGFR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">downstream-of-FGF receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gene C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hbr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">heartbroken</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">heartbroken/dof</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">i21</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">i28</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)09904</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)S083710</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sms</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stumps</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stumps/dof</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stumps</rdfs:label>
+        <oboInOwl:hasExactSynonym>0837/10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG18485</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG31317</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3375</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dof</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dof/stumps/heartbroken</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Downstream of FGF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Downstream of FGF receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Downstream of FGFR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Downstream of FGFR/Heartbroken/Stumps</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Downstream-of-FGFR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hbr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hbr/Dof</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Heartbroken</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>P1740</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Stumps</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-EST:CL47</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-estC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dof</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dof/hbr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dof/hbr/sms</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dof1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>downstream of FGF receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>downstream of FGFR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>downstream-of-FGF receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gene C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hbr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>heartbroken</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>heartbroken/dof</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>i21</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>i28</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)09904</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)S083710</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sms</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>stumps</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>stumps/dof</oboInOwl:hasExactSynonym>
+        <rdfs:label>stumps</rdfs:label>
     </owl:Class>
     
 
@@ -2051,35 +2053,35 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0020386">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1210</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1201</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1210</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DSTPK61</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dstpk61</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDK-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDK1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDK1/Pk61C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PK61C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pdpk1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phosphoinositide dependent kinase 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phosphoinositide-dependent kinase 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pk61C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pk61C/PDK1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pk61c/PDK1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein kinase 61C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dPDK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dPDK-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dPDK1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dPdk1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dSTPK61</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pdk1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pdpk1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phosphoinositide-dependent kinase 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pk61c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protein kinase 61C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">serine/threonine protein kinase</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pdk1</rdfs:label>
+        <oboInOwl:hasExactSynonym>1210</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG1201</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG1210</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DSTPK61</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dstpk61</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDK-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDK1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDK1/Pk61C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PK61C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pdpk1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Phosphoinositide dependent kinase 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Phosphoinositide-dependent kinase 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pk61C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pk61C/PDK1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pk61c/PDK1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Protein kinase 61C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dPDK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dPDK-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dPDK1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dPdk1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dSTPK61</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pdk1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pdpk1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>phosphoinositide-dependent kinase 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pk61c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>protein kinase 61C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>serine/threonine protein kinase</oboInOwl:hasExactSynonym>
+        <rdfs:label>Pdk1</rdfs:label>
     </owl:Class>
     
 
@@ -2088,18 +2090,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0023091">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8667</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DIMM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DIMMED</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dimm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dimmed</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mist 1-related</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mistr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bHLHa16</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">c929</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dim</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dimmed</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dimm</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG8667</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DIMM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DIMMED</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dimm</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dimmed</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mist 1-related</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mistr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bHLHa16</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>c929</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dim</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dimmed</oboInOwl:hasExactSynonym>
+        <rdfs:label>dimm</rdfs:label>
     </owl:Class>
     
 
@@ -2108,35 +2110,35 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0023178">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:RH08487</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6496</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-PDF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-PDH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-pdf</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PAP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDF C7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDF-associated peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDF-precursor PDF-associated peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PIGMENT DISPERSING FACTOR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PIGMENT-DISPERSING FACTOR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pigment Dispersing Factor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pigment dispersing factor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pigment-Dispersing Factor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pigment-dispersing factor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pigment-dispersing hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pigment-dispersing hormone-like peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0140519.261</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0140519.3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cPDH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pdf</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pigment dispersing factor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pigment dispersing hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pigment dispersion factor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pigment-dispersing factor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pigment-dispersing hormone</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pdf</rdfs:label>
+        <oboInOwl:hasExactSynonym>BcDNA:RH08487</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG6496</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-PDF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-PDH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-pdf</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PAP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDF C7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDF-associated peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDF-precursor PDF-associated peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PIGMENT DISPERSING FACTOR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PIGMENT-DISPERSING FACTOR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pigment Dispersing Factor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pigment dispersing factor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pigment-Dispersing Factor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pigment-dispersing factor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pigment-dispersing hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pigment-dispersing hormone-like peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0140519.261</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0140519.3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cPDH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pdf</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pigment dispersing factor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pigment dispersing hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pigment dispersion factor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pigment-dispersing factor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pigment-dispersing hormone</oboInOwl:hasExactSynonym>
+        <rdfs:label>Pdf</rdfs:label>
     </owl:Class>
     
 
@@ -2145,22 +2147,22 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0023523">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3206</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR2F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR62</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dor62</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EG:30B8.7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 2a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 62</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 2F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or2F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or62</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor62</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or2a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or2a</rdfs:label>
+        <oboInOwl:hasExactSynonym>2F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>2a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3206</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR2F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR62</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dor62</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EG:30B8.7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 2a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 62</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 2F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or2F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or62</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor62</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or2a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or2a</rdfs:label>
     </owl:Class>
     
 
@@ -2169,18 +2171,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0025360">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG18455</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D-Six3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dsix3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OPTIX</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Optix</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Six3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0153538.79</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">opt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optix</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">opx</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">six3</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Optix</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG18455</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D-Six3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dsix3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OPTIX</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Optix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Six3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0153538.79</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>opt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>optix</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>opx</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>six3</oboInOwl:hasExactSynonym>
+        <rdfs:label>Optix</rdfs:label>
     </owl:Class>
     
 
@@ -2189,27 +2191,27 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0025525">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BAB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BAB2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTB-II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTB-protein-II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bab2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bric a brac</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bric a brac II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bric-a-brac 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BtbII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13911</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG9102</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bab</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bab-II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bric a brac</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bric a brac 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bric a brac II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bric-a-brac</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bric-a-brac 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bric-a-brac-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bric-a-brac2</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bab2</rdfs:label>
+        <oboInOwl:hasExactSynonym>BAB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BAB2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BTB-II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BTB-protein-II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bab2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bric a brac</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bric a brac II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bric-a-brac 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BtbII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13911</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG9102</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bab</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bab-II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bric a brac</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bric a brac 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bric a brac II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bric-a-brac</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bric-a-brac 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bric-a-brac-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bric-a-brac2</oboInOwl:hasExactSynonym>
+        <rdfs:label>bab2</rdfs:label>
     </owl:Class>
     
 
@@ -2218,33 +2220,33 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0025595">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AKH R</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AKH receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AKH-R</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AKHR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adipokinetic Hormone Receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adipokinetic hormone receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Akh-R</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AkhR/GRHR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Akhr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Akhr/GRHR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BEST:GH19447</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11325</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAKHR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAKHR-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DGRHR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-AKH receptor-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRHR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRHR/CG11325</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GnRHR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gonadotropin-releasing hormone receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adipokinetic hormone receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">akhR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">akhr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gonadotrophin-releasing hormone receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gonadotropin-releasing hormone receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hormone receptor</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AkhR</rdfs:label>
+        <oboInOwl:hasExactSynonym>AKH R</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AKH receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AKH-R</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AKHR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Adipokinetic Hormone Receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Adipokinetic hormone receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Akh-R</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AkhR/GRHR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Akhr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Akhr/GRHR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BEST:GH19447</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG11325</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DAKHR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DAKHR-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DGRHR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-AKH receptor-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GRHR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GRHR/CG11325</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GnRHR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gonadotropin-releasing hormone receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>adipokinetic hormone receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>akhR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>akhr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gonadotrophin-releasing hormone receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gonadotropin-releasing hormone receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hormone receptor</oboInOwl:hasExactSynonym>
+        <rdfs:label>AkhR</rdfs:label>
     </owl:Class>
     
 
@@ -2253,32 +2255,32 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0025680">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Blue-light receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3772</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CRY</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CRYPTOCHROME</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cry</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crypochrome</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cryptochrome</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DCry</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-CRY1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmCRY</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmCRY1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmCry</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmCry1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmcry</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0140519.17</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0140519.19</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0140519.20</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0172774.15</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cry1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cryb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crybaby</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cryptochrome</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dCRY</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dCry</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dcry</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cry</rdfs:label>
+        <oboInOwl:hasExactSynonym>Blue-light receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3772</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CRY</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CRYPTOCHROME</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cry</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Crypochrome</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cryptochrome</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DCry</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-CRY1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmCRY</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmCRY1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmCry</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmCry1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmcry</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0140519.17</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0140519.19</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0140519.20</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0172774.15</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cry1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cryb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>crybaby</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cryptochrome</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dCRY</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dCry</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dcry</oboInOwl:hasExactSynonym>
+        <rdfs:label>cry</rdfs:label>
     </owl:Class>
     
 
@@ -2287,14 +2289,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0025697">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BEST:CK01577</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12789</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CK01577</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SANTA-MARIA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Santa Maria</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">santa maria</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scavenger receptor acting in neural tissue and majority of rhodopsin is absent</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">santa-maria</rdfs:label>
+        <oboInOwl:hasExactSynonym>BEST:CK01577</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG12789</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CK01577</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SANTA-MARIA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Santa Maria</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>santa maria</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>scavenger receptor acting in neural tissue and majority of rhodopsin is absent</oboInOwl:hasExactSynonym>
+        <rdfs:label>santa-maria</rdfs:label>
     </owl:Class>
     
 
@@ -2303,14 +2305,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0025739">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3346</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PON</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Partner Of Numb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Partner of Numb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Partner of numb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pon</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">partner of numb</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pon</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG3346</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PON</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Partner Of Numb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Partner of Numb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Partner of numb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pon</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>partner of numb</oboInOwl:hasExactSynonym>
+        <rdfs:label>pon</rdfs:label>
     </owl:Class>
     
 
@@ -2319,19 +2321,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026384">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">59D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">59a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG9820</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR46</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR59D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR59a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 59a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 59D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or46</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or59D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor46</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or59a</rdfs:label>
+        <oboInOwl:hasExactSynonym>59D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>59a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG9820</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR46</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR59D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR59a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 59a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 59D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or46</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or59D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor46</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or59a</rdfs:label>
     </owl:Class>
     
 
@@ -2340,19 +2342,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026385">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">47E.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">47b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13206</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR25</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR47E.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr47b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR 47b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR47b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 47b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 47E.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or47E.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or47b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or47b</rdfs:label>
+        <oboInOwl:hasExactSynonym>47E.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>47b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13206</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR25</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR47E.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr47b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR 47b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR47b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 47b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 47E.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or47E.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or47b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or47b</rdfs:label>
     </owl:Class>
     
 
@@ -2361,20 +2363,20 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026386">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">47E.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">47a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13225</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR24</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR47E.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR47a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 47a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 47E.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or24</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or47E.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor24</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or47a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or47a</rdfs:label>
+        <oboInOwl:hasExactSynonym>47E.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>47a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13225</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR24</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR47E.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR47a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 47a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 47E.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or24</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or47E.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor24</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or47a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or47a</rdfs:label>
     </owl:Class>
     
 
@@ -2383,34 +2385,34 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026388">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">46F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">46a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">46b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN8</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN9</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17848</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17849</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG33478</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR19</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR20</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR46F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR46F.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelOR46a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR46a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 46a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 46b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 46F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 46F.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or19</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or46B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or46F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or46F.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or46aA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or46aB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or46aa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or46b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor19</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or46a</rdfs:label>
+        <oboInOwl:hasExactSynonym>46F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>46a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>46b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN9</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17848</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17849</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG33478</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR19</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR20</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR46F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR46F.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelOR46a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR46a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 46a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 46b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 46F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 46F.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or19</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or46B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or46F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or46F.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or46aA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or46aB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or46aa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or46b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor19</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or46a</rdfs:label>
     </owl:Class>
     
 
@@ -2419,26 +2421,26 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026389">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">43B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">43B1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">43a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN14</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1854</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR43B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR43a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR87</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dor87</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR43a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 43a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 87</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 43B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or43A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or43B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or87</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor87</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or43a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or43a</rdfs:label>
+        <oboInOwl:hasExactSynonym>43B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>43B1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>43a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN14</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG1854</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR43B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR43a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR87</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dor87</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR43a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 43a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 87</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 43B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or43A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or43B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or87</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor87</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or43a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or43a</rdfs:label>
     </owl:Class>
     
 
@@ -2447,18 +2449,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026390">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">33B.3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">33c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5006</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR33B.3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR71</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 33c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 33B.3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or33B.3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or71</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor71</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or33c</rdfs:label>
+        <oboInOwl:hasExactSynonym>33B.3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>33c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG5006</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR33B.3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR71</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 33c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 33B.3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or33B.3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or71</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor71</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or33c</rdfs:label>
     </owl:Class>
     
 
@@ -2467,18 +2469,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026391">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">33B.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">33b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG16961</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR33B.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR72</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 33b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 33B.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or33B.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or72</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor72</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or33b</rdfs:label>
+        <oboInOwl:hasExactSynonym>33B.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>33b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG16961</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR33B.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR72</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 33b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 33B.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or33B.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or72</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor72</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or33b</rdfs:label>
     </owl:Class>
     
 
@@ -2487,18 +2489,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026392">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">33B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">33a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG16960</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR33B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR73</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 33a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 33B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or33B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or73</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor73</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or33a</rdfs:label>
+        <oboInOwl:hasExactSynonym>33B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>33a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG16960</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR33B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR73</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 33a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 33B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or33B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or73</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor73</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or33a</rdfs:label>
     </owl:Class>
     
 
@@ -2507,17 +2509,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026393">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">25A.1/43</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">43b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17853</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR25A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR81</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR43b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 43b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 25A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or25A.1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or43b</rdfs:label>
+        <oboInOwl:hasExactSynonym>25A.1/43</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>43b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17853</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR25A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR81</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR43b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 43b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 25A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or25A.1</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or43b</rdfs:label>
     </owl:Class>
     
 
@@ -2526,15 +2528,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026394">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">24D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">24a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11767</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR24D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR48</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 24a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 24D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or24D.1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or24a</rdfs:label>
+        <oboInOwl:hasExactSynonym>24D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>24a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG11767</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR24D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR48</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 24a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 24D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or24D.1</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or24a</rdfs:label>
     </owl:Class>
     
 
@@ -2543,22 +2545,22 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026395">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">23A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">23a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG9880</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR23A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR64, AN5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dor64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 23a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 23A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or23A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or23a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or23a</rdfs:label>
+        <oboInOwl:hasExactSynonym>23A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>23a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG9880</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR23A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR64, AN5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dor64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 23a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 23A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or23A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or23a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or23a</rdfs:label>
     </owl:Class>
     
 
@@ -2567,15 +2569,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026396">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">22C.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">22c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15377</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR16</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR22C.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 22c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 22C.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or22C.1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or22c</rdfs:label>
+        <oboInOwl:hasExactSynonym>22C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>22c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG15377</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR16</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR22C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 22c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 22C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or22C.1</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or22c</rdfs:label>
     </owl:Class>
     
 
@@ -2584,27 +2586,27 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026397">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">22A.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">22b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN12</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4231</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR22A.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR22b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR67</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmel Or22b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dor67</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR22b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 22b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 67</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 22A.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or22</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or22A.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or22a/b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or67</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dOr22b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor67</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or22b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or22b</rdfs:label>
+        <oboInOwl:hasExactSynonym>22A.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>22b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN12</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG4231</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR22A.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR22b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR67</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmel Or22b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dor67</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR22b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 22b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 67</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 22A.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or22</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or22A.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or22a/b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or67</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dOr22b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor67</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or22b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or22b</rdfs:label>
     </owl:Class>
     
 
@@ -2613,28 +2615,28 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026398">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">22A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">22a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN11</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12193</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR22A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR22a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR53</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr22a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmel Or22a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmel22a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dor53</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR22a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 22a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 53</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 22A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or22</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or22A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or22a/b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or53</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dOr22a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor53</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or22a</rdfs:label>
+        <oboInOwl:hasExactSynonym>22A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>22a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN11</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG12193</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR22A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR22a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR53</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr22a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmel Or22a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmel22a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dor53</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR22a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 22a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 53</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 22A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or22</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or22A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or22a/b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or53</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dOr22a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor53</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or22a</rdfs:label>
     </owl:Class>
     
 
@@ -2643,20 +2645,20 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0026399">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG9700</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CR9700</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR104</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR85e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dor104</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR55</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR85e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 104</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 85e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or104</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dor104</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or85e</rdfs:label>
+        <oboInOwl:hasExactSynonym>85B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>85e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG9700</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CR9700</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR104</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR85e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dor104</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR55</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR85e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 104</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 85e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or104</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dor104</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or85e</rdfs:label>
     </owl:Class>
     
 
@@ -2665,27 +2667,27 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0027109">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10342</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-NPF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmNPF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-NPF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NP-PP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NPF-A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NPF-A2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NPF/NPY</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NPF89D3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NPY-like neuropeptide F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neuropeptide F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neuropeptide F 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Npf</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dNPF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dnpf</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long neuropeptide F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">neuropeptide F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">neuropeptide-F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">npf</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NPF</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG10342</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-NPF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmNPF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-NPF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NP-PP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NPF-A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NPF-A2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NPF/NPY</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NPF89D3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NPY-like neuropeptide F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Neuropeptide F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Neuropeptide F 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Npf</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dNPF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dnpf</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>long neuropeptide F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>neuropeptide F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>neuropeptide-F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>npf</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF</oboInOwl:hasExactSynonym>
+        <rdfs:label>NPF</rdfs:label>
     </owl:Class>
     
 
@@ -2694,20 +2696,20 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0027343">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG16785</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DFz3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dfrizzled-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dfz3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm Fz3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EG:34F3.6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Frizzled 3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fz3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dFrizzled3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dFz3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dfz3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frizzled 3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frizzled3</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fz3</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG16785</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DFz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dfrizzled-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dfz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm Fz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EG:34F3.6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Frizzled 3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Fz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dFrizzled3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dFz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dfz3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>frizzled 3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>frizzled3</oboInOwl:hasExactSynonym>
+        <rdfs:label>fz3</rdfs:label>
     </owl:Class>
     
 
@@ -2716,11 +2718,11 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0027945">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7758</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)00217</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)78Cb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pumpless</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ppl</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG7758</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)00217</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)78Cb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pumpless</oboInOwl:hasExactSynonym>
+        <rdfs:label>ppl</rdfs:label>
     </owl:Class>
     
 
@@ -2729,37 +2731,37 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0028374">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6371</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-MT2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-PK-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HUG</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HUGIN</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HUGgamma</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hug-PK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hug-gamma</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hugin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hugin PK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hugin-PK-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hugin-gamma</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hugin-pyrokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PK-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pyrokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SVPFKPRLamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hug</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hug gamma</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hug-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hug-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hug-PK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hug-gamma</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hugg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">huggamma</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hugin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hugin gamma</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">huginPK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pyrokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pyrokinin-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pyrokinin/PBAN-like</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hug</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG6371</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-MT2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-PK-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>HUG</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>HUGIN</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>HUGgamma</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hug-PK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hug-gamma</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hugin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hugin PK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hugin-PK-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hugin-gamma</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hugin-pyrokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PK-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pyrokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SVPFKPRLamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hug</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hug gamma</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hug-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hug-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hug-PK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hug-gamma</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hugg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>huggamma</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hugin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hugin gamma</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>huginPK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pyrokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pyrokinin-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pyrokinin/PBAN-like</oboInOwl:hasExactSynonym>
+        <rdfs:label>Hug</rdfs:label>
     </owl:Class>
     
 
@@ -2768,29 +2770,29 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0028418">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13480</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DLK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-KIN</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LCK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leucokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leucokinin-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leucokinin-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leuk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leukokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drosokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">leuc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">leucokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">leucokinin precursor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">leukokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">leukokinin neuropeptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myokinin-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pp</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lk</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG13480</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DLK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-KIN</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Kinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LCK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Leucokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Leucokinin-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Leucokinin-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Leuk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Leukokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drosokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>kinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>leuc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>leucokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>leucokinin precursor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>leukokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>leukokinin neuropeptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myokinin-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pp</oboInOwl:hasExactSynonym>
+        <rdfs:label>Lk</rdfs:label>
     </owl:Class>
     
 
@@ -2799,16 +2801,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0028430">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG31770</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustav</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">H2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hemes</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hemese</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">he</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hem</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hemes</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hemese</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">He</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG31770</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustav</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>H2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hemes</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Hemese</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>he</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hem</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hemes</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hemese</oboInOwl:hasExactSynonym>
+        <rdfs:label>He</rdfs:label>
     </owl:Class>
     
 
@@ -2817,19 +2819,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0028841">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BG:DS09218.5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17330</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmJHAMT</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">JAHMT</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">JHAMT</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">JHamt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jhamt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Juvenile Hormone Acid O-Methyl Transferase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Juvenile Hormone Acid O-Methyltransferase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Juvenile hormone acid O-methyltransferase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Juvenile hormone acid methyl transferase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">juvenile hormone acid methyltransferase</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jhamt</rdfs:label>
+        <oboInOwl:hasExactSynonym>BG:DS09218.5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17330</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmJHAMT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>JAHMT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>JHAMT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>JHamt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Jhamt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Juvenile Hormone Acid O-Methyl Transferase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Juvenile Hormone Acid O-Methyltransferase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Juvenile hormone acid O-methyltransferase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Juvenile hormone acid methyl transferase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>juvenile hormone acid methyltransferase</oboInOwl:hasExactSynonym>
+        <rdfs:label>jhamt</rdfs:label>
     </owl:Class>
     
 
@@ -2838,15 +2840,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0028946">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">35a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">36E.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BACR44L22.5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BG:BACR44L22.5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17868</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR91</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR35a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 35a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or35a</rdfs:label>
+        <oboInOwl:hasExactSynonym>35a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>36E.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BACR44L22.5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BG:BACR44L22.5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17868</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR91</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR35a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 35a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or35a</rdfs:label>
     </owl:Class>
     
 
@@ -2855,16 +2857,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0028963">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">49D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">49b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AN13</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17584</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR105</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr49b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR49b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 49b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or-49b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or49b</rdfs:label>
+        <oboInOwl:hasExactSynonym>49D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>49b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AN13</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17584</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR105</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr49b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR49b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 49b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or-49b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or49b</rdfs:label>
     </owl:Class>
     
 
@@ -2873,13 +2875,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0029521">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17885</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR68</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR1a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 1a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or1a</rdfs:label>
+        <oboInOwl:hasExactSynonym>1A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>1a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17885</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR68</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR1a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 1a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or1a</rdfs:label>
     </owl:Class>
     
 
@@ -2888,17 +2890,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0029768">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12731</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG16752</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DrmSPR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SP receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sex Peptide Receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sex peptide Receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sex peptide receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sex peptide receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spr</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SPR</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG12731</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG16752</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DrmSPR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SP receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SP-R</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sex Peptide Receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sex peptide Receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sex peptide receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Spr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sex peptide receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spr</oboInOwl:hasExactSynonym>
+        <rdfs:label>SPR</rdfs:label>
     </owl:Class>
     
 
@@ -2907,16 +2910,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0030016">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">7a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10759</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR30</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOR7a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelOr7a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR7a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 7a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or7A</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or7a</rdfs:label>
+        <oboInOwl:hasExactSynonym>7D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>7a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG10759</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR30</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOR7a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelOr7a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR7a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 7a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or7A</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or7a</rdfs:label>
     </owl:Class>
     
 
@@ -2925,15 +2928,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0030204">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9E.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15302</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR95</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr9a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR9a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 9a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or9a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or9a</rdfs:label>
+        <oboInOwl:hasExactSynonym>9E.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>9a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG15302</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR95</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr9a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR9a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 9a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or9a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or9a</rdfs:label>
     </owl:Class>
     
 
@@ -2942,15 +2945,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0030298">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">10B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">10a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17867</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR92</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr10a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR10a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 10a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">odorant receptor 10a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or10a</rdfs:label>
+        <oboInOwl:hasExactSynonym>10B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>10a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17867</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR92</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr10a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR10a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 10a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>odorant receptor 10a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or10a</rdfs:label>
     </owl:Class>
     
 
@@ -2959,32 +2962,32 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0030608">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">145098_at</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG9057</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmPLIN2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LSD</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LSD-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LSD2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LSP-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lipid Storage Droplet 2 Gene</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lipid Storage Droplet protein 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lipid storage droplet 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lipid storage droplet-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lipid-storage Droplet-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lsd2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLIN2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Perilipin2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Plin2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dPlin2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dmPLIN2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lipid storage droplet 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lipid storage droplet-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lsd-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lsd2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perilipin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perilipin-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">plin2</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lsd-2</rdfs:label>
+        <oboInOwl:hasExactSynonym>145098_at</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG9057</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmPLIN2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LSD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LSD-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LSD2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LSP-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lipid Storage Droplet 2 Gene</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lipid Storage Droplet protein 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lipid storage droplet 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lipid storage droplet-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lipid-storage Droplet-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lsd2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PLIN2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Perilipin2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Plin2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dPlin2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dmPLIN2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lipid storage droplet 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lipid storage droplet-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lsd-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lsd2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>perilipin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>perilipin-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>plin2</oboInOwl:hasExactSynonym>
+        <rdfs:label>Lsd-2</rdfs:label>
     </owl:Class>
     
 
@@ -2993,15 +2996,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0030715">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">13F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">13a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12697</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR38</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR13a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 13a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dOr13a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or13a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or13a</rdfs:label>
+        <oboInOwl:hasExactSynonym>13F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>13a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG12697</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR38</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR13a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 13a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dOr13a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or13a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or13a</rdfs:label>
     </owl:Class>
     
 
@@ -3010,13 +3013,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0030795">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4805</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPK-28</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPK28</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ppk28</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pickpocket 28</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ppk-28</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ppk28</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG4805</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPK-28</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPK28</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ppk28</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pickpocket 28</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ppk-28</oboInOwl:hasExactSynonym>
+        <rdfs:label>ppk28</rdfs:label>
     </owl:Class>
     
 
@@ -3025,13 +3028,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0030844">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8527</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPK-23</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPK23</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ppk23</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pickpocket 23</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ppk-23</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ppk23</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG8527</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPK-23</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPK23</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ppk23</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pickpocket 23</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ppk-23</oboInOwl:hasExactSynonym>
+        <rdfs:label>ppk23</rdfs:label>
     </owl:Class>
     
 
@@ -3040,12 +3043,12 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0030900">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15064</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Holes in Muscles</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Holes in muscle</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">him</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">holes-in-muscle</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Him</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG15064</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Holes in Muscles</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Holes in muscle</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>him</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>holes-in-muscle</oboInOwl:hasExactSynonym>
+        <rdfs:label>Him</rdfs:label>
     </owl:Class>
     
 
@@ -3054,15 +3057,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0031209">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">21a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG2657</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT8983</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR21a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR21a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 21a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 21a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ir21a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir21a</rdfs:label>
+        <oboInOwl:hasExactSynonym>21a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG2657</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT8983</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR21a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR21a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 21a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 21a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ir21a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir21a</rdfs:label>
     </owl:Class>
     
 
@@ -3071,16 +3074,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0031903">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4971</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D-Wnt-10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DWnt-10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DWnt10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm DWnt10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dwnt-10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dwnt10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wnt oncogene analog 10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wnt10</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wnt10</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG4971</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D-Wnt-10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DWnt-10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DWnt10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm DWnt10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dwnt-10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dwnt10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Wnt oncogene analog 10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>wnt10</oboInOwl:hasExactSynonym>
+        <rdfs:label>Wnt10</rdfs:label>
     </owl:Class>
     
 
@@ -3089,28 +3092,28 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0032048">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13094</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calcitonin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calcitonin-like diuretic hormone (31 residues)</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH 31</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH-II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH31</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH[31]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH[[31]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH[[31]]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dh[[31]]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diuretic Hormone 31</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diuretic hormone 31</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-DH[[31]]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drome-DH[[31]]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-EST:Posey114</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO02059370.45</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dh31</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diuretic Hormone 31</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diuretic hormone</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">diuretic hormone 31</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drome-DH31</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dh31</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG13094</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Calcitonin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Calcitonin-like diuretic hormone (31 residues)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH 31</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH-II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH31</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH[31]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH[[31]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH[[31]]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dh[[31]]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Diuretic Hormone 31</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Diuretic hormone 31</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-DH[[31]]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drome-DH[[31]]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-EST:Posey114</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO02059370.45</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dh31</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>diuretic Hormone 31</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>diuretic hormone</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>diuretic hormone 31</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drome-DH31</oboInOwl:hasExactSynonym>
+        <rdfs:label>Dh31</rdfs:label>
     </owl:Class>
     
 
@@ -3119,13 +3122,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0032096">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">30A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">30a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13106</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR56</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR30a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 30a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or30a</rdfs:label>
+        <oboInOwl:hasExactSynonym>30A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>30a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13106</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR56</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR30a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 30a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or30a</rdfs:label>
     </owl:Class>
     
 
@@ -3134,33 +3137,33 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0032336">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AST-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASTC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin Manduca-type</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ast-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ast2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BEST:GH06087</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:RH36507</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14919</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG149199</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAP-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-AST C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-AST-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drostatin-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FLT</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Flt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">M-ASH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ast2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drostatin-C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">flatline</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">flt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gh06087</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstC</rdfs:label>
+        <oboInOwl:hasExactSynonym>ASC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AST-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ASTC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin Manduca-type</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ast-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ast2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BEST:GH06087</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BcDNA:RH36507</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14919</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG149199</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DAP-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-AST C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-AST-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drostatin-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>FLT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Flt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>M-ASH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ast2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drostatin-C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>flatline</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>flt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gh06087</oboInOwl:hasExactSynonym>
+        <rdfs:label>AstC</rdfs:label>
     </owl:Class>
     
 
@@ -3169,11 +3172,11 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0032422">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Atilla</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6579</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">L1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atilla</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atilla</rdfs:label>
+        <oboInOwl:hasExactSynonym>Atilla</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG6579</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>L1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>atilla</oboInOwl:hasExactSynonym>
+        <rdfs:label>atilla</rdfs:label>
     </owl:Class>
     
 
@@ -3182,48 +3185,48 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0032840">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">38B.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13968</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-sNPF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-sNPF-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-sNPF-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-sNPF-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-sNPF-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-sNPF-AP1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LRLRFamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LRLRFamides</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neuropeptide F (short)</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SMALL NEUROPEPTIDE F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SNPF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Short NPF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Short Neuropeptide F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Short neuropeptide F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lrlrfa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">precursor of short neuropeptide F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">s-NPF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF precursor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF-1[4-11]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF-2[12-19]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF-2s</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF1[1-11]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF1[4-11</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF2[12-19]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short NPF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short neuropeptide F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short neuropeptide F precursor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short neuropeptide F-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short neuropeptide F1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">small neuropeptide F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">small neuropeptide F-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">small neuropeptide-F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snpf</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sNPF</rdfs:label>
+        <oboInOwl:hasExactSynonym>38B.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13968</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-sNPF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-sNPF-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-sNPF-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-sNPF-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-sNPF-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-sNPF-AP1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LRLRFamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LRLRFamides</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Neuropeptide F (short)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SMALL NEUROPEPTIDE F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SNPF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Short NPF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Short Neuropeptide F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Short neuropeptide F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lrlrfa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>precursor of short neuropeptide F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>s-NPF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF precursor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF-1[4-11]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF-2[12-19]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF-2s</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF1[1-11]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF1[4-11</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF2[12-19]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sNPF3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>short NPF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>short neuropeptide F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>short neuropeptide F precursor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>short neuropeptide F-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>short neuropeptide F1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>small neuropeptide F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>small neuropeptide F-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>small neuropeptide-F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>snpf</oboInOwl:hasExactSynonym>
+        <rdfs:label>sNPF</rdfs:label>
     </owl:Class>
     
 
@@ -3232,14 +3235,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0033041">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">41E.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">42a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17250</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR117</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR42a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 42a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or42A</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or42a</rdfs:label>
+        <oboInOwl:hasExactSynonym>41E.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>42a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17250</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR117</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR42a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 42a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or42A</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or42a</rdfs:label>
     </owl:Class>
     
 
@@ -3248,14 +3251,36 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0033043">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">41E.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">42b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12754</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR118</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR42b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 42b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or42</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or42b</rdfs:label>
+        <oboInOwl:hasExactSynonym>41E.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>42b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG12754</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR118</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR42b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 42b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or42</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or42b</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://flybase.org/reports/FBgn0033096 -->
+
+    <owl:Class rdf:about="http://flybase.org/reports/FBgn0033096">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
+        <oboInOwl:hasExactSynonym>CG9428</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ZIP1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ZIP42C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zinc/iron regulated transporter-related protein 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zinc/iron regulated transporter-related protein 42C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zinc/iron transporter-related protein 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Zip1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cg9428</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dZIP1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dZIP42C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dZip1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dZip42C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dzip1</oboInOwl:hasExactSynonym>
+        <rdfs:label>Zip42C.1</rdfs:label>
     </owl:Class>
     
 
@@ -3264,12 +3289,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0033259">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11210</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT31310</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TMEM63</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transmembrane protein 63</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tmem63</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tmem63</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG11210</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT31310</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OSCA/TMEM63</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TMEM63</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Transmembrane protein 63</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tmem63</oboInOwl:hasExactSynonym>
+        <rdfs:label>Tmem63</rdfs:label>
     </owl:Class>
     
 
@@ -3278,18 +3304,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0033327">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8577</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT8705</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGRP SC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGRP-SC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGRP-SC1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGRP-SC1B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peptidoglycan recognition protein SC1b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peptidoglycan-recognition protein-SC1b precursor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SC1B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pgrp-sc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pgrp-sc1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGRP-SC1b</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG8577</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT8705</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PGRP SC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PGRP-SC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PGRP-SC1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PGRP-SC1B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Peptidoglycan recognition protein SC1b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Peptidoglycan-recognition protein-SC1b precursor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SC1B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pgrp-sc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pgrp-sc1</oboInOwl:hasExactSynonym>
+        <rdfs:label>PGRP-SC1b</rdfs:label>
     </owl:Class>
     
 
@@ -3298,20 +3324,20 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0033367">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8193</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmePPO2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PO45</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phenoloxidase A3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ProPO45</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prophenoloxidase 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phenoloxidase subunit A3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ppo2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">proPO45</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">proPOA(3)</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">proPo-A3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prophenoloxidase 45</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPO2</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG8193</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmePPO2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PO45</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Phenoloxidase A3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ProPO45</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Prophenoloxidase 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>phenoloxidase subunit A3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ppo2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>proPO45</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>proPOA(3)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>proPo-A3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>prophenoloxidase 45</oboInOwl:hasExactSynonym>
+        <rdfs:label>PPO2</rdfs:label>
     </owl:Class>
     
 
@@ -3320,12 +3346,12 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0033404">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">45C.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">45a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1978</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR58</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 45a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or45a</rdfs:label>
+        <oboInOwl:hasExactSynonym>45C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>45a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG1978</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR58</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 45a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or45a</rdfs:label>
     </owl:Class>
     
 
@@ -3334,12 +3360,12 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0033422">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">45F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">45b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12931</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR107</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 45b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or45b</rdfs:label>
+        <oboInOwl:hasExactSynonym>45F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>45b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG12931</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR107</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 45b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or45b</rdfs:label>
     </owl:Class>
     
 
@@ -3348,9 +3374,9 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0033725">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8502</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cuticular protein 49Ac</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cpr49Ac</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG8502</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cuticular protein 49Ac</oboInOwl:hasExactSynonym>
+        <rdfs:label>Cpr49Ac</rdfs:label>
     </owl:Class>
     
 
@@ -3359,14 +3385,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0033727">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">49A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">49a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13158</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr49a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR49a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 49a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or49a</rdfs:label>
+        <oboInOwl:hasExactSynonym>49A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>49a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13158</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr49a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR49a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 49a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or49a</rdfs:label>
     </owl:Class>
     
 
@@ -3375,20 +3401,20 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0033744">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12370</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13156</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CRF-like diuretic hormonereceptor 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH-R</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH44-R2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH44R2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DH[[44]]-R2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dh44 receptor 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dh442</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dh44R2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diuretic hormone 44 receptor 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0170980.103</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0170980.104</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dh44-R2</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG12370</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13156</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CRF-like diuretic hormonereceptor 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH-R</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH44-R2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH44R2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DH[[44]]-R2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dh44 receptor 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dh442</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dh44R2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Diuretic hormone 44 receptor 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0170980.103</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0170980.104</oboInOwl:hasExactSynonym>
+        <rdfs:label>Dh44-R2</rdfs:label>
     </owl:Class>
     
 
@@ -3397,13 +3423,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0034458">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">56d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15904</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR56d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR56d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 56d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 56d</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir56d</rdfs:label>
+        <oboInOwl:hasExactSynonym>56d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG15904</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR56d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR56d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 56d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 56d</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir56d</rdfs:label>
     </owl:Class>
     
 
@@ -3412,16 +3438,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0034473">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">56E.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">56a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12501</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR59</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr56a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR56a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 56a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or-56a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">odorant receptor 56a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or56a</rdfs:label>
+        <oboInOwl:hasExactSynonym>56E.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>56a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG12501</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR59</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr56a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR56a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 56a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or-56a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>odorant receptor 56a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or56a</rdfs:label>
     </owl:Class>
     
 
@@ -3430,16 +3456,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0034865">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">59E.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">59b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3569</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR119</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOR59B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr59b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR59b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 59b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or59B</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or59b</rdfs:label>
+        <oboInOwl:hasExactSynonym>59E.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>59b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3569</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR119</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOR59B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr59b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR59b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 59b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or59B</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or59b</rdfs:label>
     </owl:Class>
     
 
@@ -3448,12 +3474,12 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0034866">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">59E.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">59c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17226</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR120</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 59c</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or59c</rdfs:label>
+        <oboInOwl:hasExactSynonym>59E.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>59c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17226</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR120</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 59c</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or59c</rdfs:label>
     </owl:Class>
     
 
@@ -3462,18 +3488,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0034935">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:RH09340</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13565</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1565</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm Orcokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OK-A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OK-B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orco</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orcokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orcokinin B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">orcokinin</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orcokinin</rdfs:label>
+        <oboInOwl:hasExactSynonym>BcDNA:RH09340</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13565</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG1565</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm Orcokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OK-A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OK-B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Orco</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Orcokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Orcokinin B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>orcokinin</oboInOwl:hasExactSynonym>
+        <rdfs:label>Orcokinin</rdfs:label>
     </owl:Class>
     
 
@@ -3482,21 +3508,21 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0035023">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:SD05282</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13586</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHH-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-ITP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DrmITP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DrmITPL1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DrmITPL2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ION TRANSPORT PEPTIDE</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ion transport peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Itp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chgh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ion transport peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ion transport polypeptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">itp</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ITP</rdfs:label>
+        <oboInOwl:hasExactSynonym>BcDNA:SD05282</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13586</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CHH-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-ITP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DrmITP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DrmITPL1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DrmITPL2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ION TRANSPORT PEPTIDE</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ion transport peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Itp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>chgh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ion transport peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ion transport polypeptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>itp</oboInOwl:hasExactSynonym>
+        <rdfs:label>ITP</rdfs:label>
     </owl:Class>
     
 
@@ -3505,25 +3531,25 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0035092">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">APK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">APK peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3441</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IPNa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IPNamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IPNamide peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MTY-amide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MTYa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MTYamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MTYamide peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NPLP-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NPLP1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neuropeptide like precursor 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neuropeptide like precursor protein 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neuropeptide-like precursor 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VQQ</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">neuropeptide-like precursor 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nplp1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nplp1</rdfs:label>
+        <oboInOwl:hasExactSynonym>APK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>APK peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3441</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IPNa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IPNamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IPNamide peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MTY-amide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MTYa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MTYamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MTYamide peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NPLP-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NPLP1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Neuropeptide like precursor 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Neuropeptide like precursor protein 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Neuropeptide-like precursor 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>VQQ</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>neuropeptide-like precursor 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nplp1</oboInOwl:hasExactSynonym>
+        <rdfs:label>Nplp1</rdfs:label>
     </owl:Class>
     
 
@@ -3532,9 +3558,9 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0035282">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13936</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CNMamide</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CNMa</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG13936</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CNMamide</oboInOwl:hasExactSynonym>
+        <rdfs:label>CNMa</rdfs:label>
     </owl:Class>
     
 
@@ -3543,14 +3569,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0035382">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">63B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">63a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG9969</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR28</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR63a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 63a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or63aA</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or63a</rdfs:label>
+        <oboInOwl:hasExactSynonym>63B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>63a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG9969</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR28</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR63a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 63a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or63aA</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or63a</rdfs:label>
     </owl:Class>
     
 
@@ -3559,14 +3585,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0035468">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14979</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGr63a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR63a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr63F1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 63F1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 63a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gr63a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr63a</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14979</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGr63a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR63a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr63F1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 63F1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 63a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gr63a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr63a</rdfs:label>
     </owl:Class>
     
 
@@ -3575,13 +3601,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0035486">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14987</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG33157</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmel64d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR64d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 64d</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64d</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14987</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG33157</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmel64d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR64d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 64d</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr64d</rdfs:label>
     </owl:Class>
     
 
@@ -3590,18 +3616,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0035604">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">64a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10633</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT29782</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmIr64a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR64a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR64A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR64a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 64a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 64a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ir64a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir64a</rdfs:label>
+        <oboInOwl:hasExactSynonym>64a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG10633</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT29782</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmIr64a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR64a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR64A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR64a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 64a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ir64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 64a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ir64a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir64a</rdfs:label>
     </owl:Class>
     
 
@@ -3610,22 +3636,22 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0035610">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10626</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DLKR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosokinin receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kinin receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LK-R</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LKR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leucokinin R</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leucokinin receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LkR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0131005.17</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0170980.118</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0170980.119</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dLKR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">leucokinin receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lkr</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lkr</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG10626</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DLKR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosokinin receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Kinin receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LK-R</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LKR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Leucokinin R</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Leucokinin receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LkR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0131005.17</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0170980.118</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0170980.119</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dLKR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>leucokinin receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lkr</oboInOwl:hasExactSynonym>
+        <rdfs:label>Lkr</rdfs:label>
     </owl:Class>
     
 
@@ -3634,17 +3660,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0035870">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7189</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR66A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR66C1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR66a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr66</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr66A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr66C1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 66C1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 66a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gustatory receptor 66a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr66a</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG7189</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR66A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR66C1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR66a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr66</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr66A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr66C1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 66C1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 66a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gustatory receptor 66a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr66a</rdfs:label>
     </owl:Class>
     
 
@@ -3653,36 +3679,36 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0035934">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ANKTM1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anktm1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5751</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5761</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT18073</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmTRPA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TRPA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TRPA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TrPA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transient receptor potential A 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transient receptor potential A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transient receptor potential cation channel</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transient receptor potential cation channel A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transient receptor potential cation channel A1 ortholog</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trp1A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TrpA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trpa1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dANKTM1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dTRPA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dTRPA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dTrpA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dTrpA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dmTRPA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dtrpA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transient receptor potential A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transient-receptor-potential A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trpA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trpa1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TrpA1</rdfs:label>
+        <oboInOwl:hasExactSynonym>ANKTM1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Anktm1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG5751</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG5761</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT18073</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmTRPA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TRPA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TRPA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TrPA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Transient receptor potential A 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Transient receptor potential A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Transient receptor potential cation channel</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Transient receptor potential cation channel A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Transient receptor potential cation channel A1 ortholog</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Trp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Trp1A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TrpA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Trpa1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dANKTM1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dTRPA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dTRPA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dTrpA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dTrpA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dmTRPA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dtrpA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>transient receptor potential A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>transient-receptor-potential A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>trpA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>trpa1</oboInOwl:hasExactSynonym>
+        <rdfs:label>TrpA1</rdfs:label>
     </owl:Class>
     
 
@@ -3691,15 +3717,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036009">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">67B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">67a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12526</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR84</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOR67a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr67a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 67a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">odorant receptor 67a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or67a</rdfs:label>
+        <oboInOwl:hasExactSynonym>67B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>67a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG12526</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR84</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOR67a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr67a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelOr67a.P</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 67a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>odorant receptor 67a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or67a</rdfs:label>
     </owl:Class>
     
 
@@ -3708,13 +3735,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036019">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">67B.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">67b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14176</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr67b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR67b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 67b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or67b</rdfs:label>
+        <oboInOwl:hasExactSynonym>67B.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>67b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14176</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr67b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR67b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 67b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or67b</rdfs:label>
     </owl:Class>
     
 
@@ -3723,47 +3750,49 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036046">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Akh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8167</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILP 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILP-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILP2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILPs</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dilp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dilp 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dilp-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dilp2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosophila insulin like peptide 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosophila insulin-like peptide 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosophila insulin-like receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ILP-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ILP2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ILPs</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IRP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IlP2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ilp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ilp-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin- related peptide 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin-like peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin-like peptide 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin-related peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dILP-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dILP2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dIlp2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dilp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dilp-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dilp2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dipl2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dlp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ilp2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin-like 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin-like peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin-like peptide 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin-like peptide-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin/insulin-like growth factor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">llp2</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ilp2</rdfs:label>
+        <oboInOwl:hasExactSynonym>Akh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG8167</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILP 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILP-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILP2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILPs</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dilp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dilp 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dilp-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dilp1-5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dilp2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosophila insulin like peptide 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosophila insulin-like peptide 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosophila insulin-like receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ILP-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ILP2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ILPs</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IRP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IlP2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ilp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ilp-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin- related peptide 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin-like peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin-like peptide 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin-related peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dILP-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dILP2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dIlp2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dilp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dilp 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dilp-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dilp2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dipl2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dlp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ilp2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin-like 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin-like peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin-like peptide 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin-like peptide-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin/insulin-like growth factor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>llp2</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ilp2</rdfs:label>
     </owl:Class>
     
 
@@ -3772,14 +3801,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036078">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">67D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">67c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14156</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR77</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOR67C</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR67c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 67c</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or67c</rdfs:label>
+        <oboInOwl:hasExactSynonym>67D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>67c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14156</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR77</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOR67C</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR67c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 67c</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or67c</rdfs:label>
     </owl:Class>
     
 
@@ -3788,15 +3817,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036080">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">67d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14157</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr67d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelOr67d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR67d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 67d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Olfactory receptor 67d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or67d</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or67d</rdfs:label>
+        <oboInOwl:hasExactSynonym>67d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14157</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr67d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelOr67d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR67d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 67d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Olfactory receptor 67d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or67d</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or67d</rdfs:label>
     </owl:Class>
     
 
@@ -3805,14 +3834,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036150">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">68a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6185</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT19410</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR68a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR68a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 68a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 68a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir68a</rdfs:label>
+        <oboInOwl:hasExactSynonym>68a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG6185</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT19410</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR68a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR68a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 68a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 68a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir68a</rdfs:label>
     </owl:Class>
     
 
@@ -3821,17 +3850,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036260">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5638</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DMELRH7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RH7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rh</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhodopsin 7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0170980.34</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-WO0170980.35</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rh7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhodopsin</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rh7</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG5638</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DMELRH7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RH7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rh</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rhodopsin 7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0170980.34</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-WO0170980.35</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rh7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rhodopsin</oboInOwl:hasExactSynonym>
+        <rdfs:label>Rh7</rdfs:label>
     </owl:Class>
     
 
@@ -3840,19 +3869,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036414">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5842</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT18317</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmNan</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Iav</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NAN</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NANCHUNG</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nan</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nanchung</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OCR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TRPV</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nanchung</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transient receptor potential vanilloid</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nan</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG5842</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT18317</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmNan</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Iav</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NAN</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NANCHUNG</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Nan</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Nanchung</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OCR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TRPV</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nanchung</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>transient receptor potential vanilloid</oboInOwl:hasExactSynonym>
+        <rdfs:label>nan</rdfs:label>
     </owl:Class>
     
 
@@ -3861,19 +3890,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036474">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">71B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">71a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17871</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR14</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr71a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelOR71a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR71a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 71a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or71aA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or71aD</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or71c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or71a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or71a</rdfs:label>
+        <oboInOwl:hasExactSynonym>71B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>71a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17871</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR14</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr71a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelOR71a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR71a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 71a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or71aA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or71aD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or71c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or71a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or71a</rdfs:label>
     </owl:Class>
     
 
@@ -3882,13 +3911,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036709">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">74A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">74a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13726</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR26</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR74a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 74a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or74a</rdfs:label>
+        <oboInOwl:hasExactSynonym>74A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>74a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13726</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR26</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR74a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 74a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or74a</rdfs:label>
     </owl:Class>
     
 
@@ -3897,60 +3926,60 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036713">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AST-B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin cricket-type</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allostatin B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ast-B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstB-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstB/MIP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6456</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAP-B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmMIP1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmMIP2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmMIP3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmMIP4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmMIP5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-MIP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-MIP-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-MIP-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-MIP-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-MIP-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-MIP-5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drostatin-B1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drostatin-B2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drostatin-B3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drostatin-B4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drostatin-B5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP-5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mioinhibiting Peptide Precursor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mip-like peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myoinhibiting peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myoinhibiting peptide precursor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myoinhibitory peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin (B-type)</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin B-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin-B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">allatostatin-B1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drostatin-B2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mip</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myoinhibiting peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myoinhibiting peptide precursor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myoinhibitory peptide</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mip</rdfs:label>
+        <oboInOwl:hasExactSynonym>ASB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AST-B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin cricket-type</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allostatin B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ast-B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstB-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstB/MIP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG6456</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DAP-B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmMIP1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmMIP2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmMIP3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmMIP4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmMIP5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-MIP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-MIP-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-MIP-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-MIP-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-MIP-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-MIP-5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drostatin-B1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drostatin-B2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drostatin-B3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drostatin-B4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drostatin-B5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP-5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MIP5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mioinhibiting Peptide Precursor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mip-like peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myoinhibiting peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myoinhibiting peptide precursor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myoinhibitory peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin (B-type)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin B-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin-B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allatostatin-B1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drostatin-B2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mip</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myoinhibiting peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myoinhibiting peptide precursor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myoinhibitory peptide</oboInOwl:hasExactSynonym>
+        <rdfs:label>Mip</rdfs:label>
     </owl:Class>
     
 
@@ -3959,16 +3988,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036757">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">75a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14585</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmIr75a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR75a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR75a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR75abc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 75a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir75abc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 75a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir75a</rdfs:label>
+        <oboInOwl:hasExactSynonym>75a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14585</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmIr75a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR75a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR75a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR75abc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 75a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ir75abc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 75a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir75a</rdfs:label>
     </owl:Class>
     
 
@@ -3977,15 +4006,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0036829">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">75d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14076</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT33663</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR75d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR75d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 75d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 75d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lr75d</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir75d</rdfs:label>
+        <oboInOwl:hasExactSynonym>75d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14076</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT33663</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR75d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR75d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 75d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 75d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lr75d</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir75d</rdfs:label>
     </owl:Class>
     
 
@@ -3994,12 +4023,12 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037322">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">83A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">83a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10612</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR44</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 83a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or83a</rdfs:label>
+        <oboInOwl:hasExactSynonym>83A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>83a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG10612</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR44</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 83a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or83a</rdfs:label>
     </owl:Class>
     
 
@@ -4008,12 +4037,12 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037399">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">83D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">83c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15581</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR116</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 83c</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or83c</rdfs:label>
+        <oboInOwl:hasExactSynonym>83D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>83c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG15581</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR116</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 83c</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or83c</rdfs:label>
     </owl:Class>
     
 
@@ -4022,14 +4051,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037501">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">84a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10101</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT28433</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR84a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR84a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 84a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 84a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir84a</rdfs:label>
+        <oboInOwl:hasExactSynonym>84a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG10101</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT28433</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR84a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR84a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 84a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 84a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir84a</rdfs:label>
     </owl:Class>
     
 
@@ -4038,17 +4067,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037576">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85A.4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7454</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR31</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOR85A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr85a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR85a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 85a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or-85a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or85a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or85a</rdfs:label>
+        <oboInOwl:hasExactSynonym>85A.4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>85a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG7454</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR31</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOR85A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr85a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR85a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 85a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or-85a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or85a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or85a</rdfs:label>
     </owl:Class>
     
 
@@ -4057,15 +4086,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037590">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11735</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR115</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOR85b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr85b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR85b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 85b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or85b</rdfs:label>
+        <oboInOwl:hasExactSynonym>85A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>85b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG11735</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR115</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOR85b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr85b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR85b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 85b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or85b</rdfs:label>
     </owl:Class>
     
 
@@ -4074,13 +4103,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037591">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85A.3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17911</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR78</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR85c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 85c</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or85c</rdfs:label>
+        <oboInOwl:hasExactSynonym>85A.3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>85c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17911</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR78</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR85c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 85c</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or85c</rdfs:label>
     </owl:Class>
     
 
@@ -4089,13 +4118,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037594">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85A.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11742</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR114</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 85d</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or85d</rdfs:label>
+        <oboInOwl:hasExactSynonym>85.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>85A.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>85d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG11742</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR114</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 85d</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or85d</rdfs:label>
     </owl:Class>
     
 
@@ -4104,11 +4133,11 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037672">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG12952</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sage</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bHLHc7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">salivary gland-expressed bHLH</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sage</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG12952</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sage</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bHLHc7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>salivary gland-expressed bHLH</oboInOwl:hasExactSynonym>
+        <rdfs:label>sage</rdfs:label>
     </owl:Class>
     
 
@@ -4117,14 +4146,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037685">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">85f</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG16755</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR32</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr85f</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR85f</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 85f</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or85f</rdfs:label>
+        <oboInOwl:hasExactSynonym>85D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>85f</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG16755</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR32</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr85f</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR85f</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 85f</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or85f</rdfs:label>
     </owl:Class>
     
 
@@ -4133,45 +4162,45 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0037976">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14734</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DTK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DTK-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DTK-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DTK-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DTK-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DTK-5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DTK-6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DTK1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DTk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmTK6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-TK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-TK-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-TK-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-TK-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-TK-4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-TK-5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-TK-6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dtk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAP-5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TK-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tachykinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tachykinin 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tachykinin 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tachykinin 4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tachykinin 5</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tachykinin-related</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tyk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dTK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dtk</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">neurokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">preprotachykinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tachykinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tachykinin-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tachykinin-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tachykinin-6</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tachykinin-like peptide</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tk</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14734</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DTK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DTK-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DTK-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DTK-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DTK-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DTK-5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DTK-6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DTK1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DTk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmTK6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-TK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-TK-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-TK-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-TK-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-TK-4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-TK-5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-TK-6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dtk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TAP-5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TK-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tachykinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tachykinin 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tachykinin 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tachykinin 4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tachykinin 5</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tachykinin-related</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tyk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dTK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dtk</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>neurokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>preprotachykinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tachykinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tachykinin-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tachykinin-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tachykinin-6</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tachykinin-like peptide</oboInOwl:hasExactSynonym>
+        <rdfs:label>Tk</rdfs:label>
     </owl:Class>
     
 
@@ -4180,20 +4209,21 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0038147">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:RE10132</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCH2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHamid2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHamide 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHamide-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHamide2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCha2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14375</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-CCHa2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-CCHamide-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ccha2</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHa2</rdfs:label>
+        <oboInOwl:hasExactSynonym>BcDNA:RE10132</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCH2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCH2a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCHamid2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCHamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCHamide 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCHamide-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCHamide2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCha2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14375</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-CCHa2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-CCHamide-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ccha2</oboInOwl:hasExactSynonym>
+        <rdfs:label>CCHa2</rdfs:label>
     </owl:Class>
     
 
@@ -4202,19 +4232,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0038199">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCH1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHamide 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHamide-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHamide1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCM</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCha1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14358</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-CCHa1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-CCHamide-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ccha1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCHa1</rdfs:label>
+        <oboInOwl:hasExactSynonym>CCH1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCHA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCHamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCHamide 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCHamide-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCHamide1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CCha1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14358</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-CCHa1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-CCHamide-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ccha1</oboInOwl:hasExactSynonym>
+        <rdfs:label>CCHa1</rdfs:label>
     </owl:Class>
     
 
@@ -4223,15 +4253,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0038203">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">88A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">88a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14360</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR99</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr88a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR88a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 88a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or88a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or88a</rdfs:label>
+        <oboInOwl:hasExactSynonym>88A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>88a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14360</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR99</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr88a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR88a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 88a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or88a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or88a</rdfs:label>
     </owl:Class>
     
 
@@ -4240,9 +4270,9 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0038309">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ammonium transporter</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6499</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amt</rdfs:label>
+        <oboInOwl:hasExactSynonym>Ammonium transporter</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG6499</oboInOwl:hasExactSynonym>
+        <rdfs:label>Amt</rdfs:label>
     </owl:Class>
     
 
@@ -4251,10 +4281,10 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0038343">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14871</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trissin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trissin</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trissin</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14871</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Trissin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>trissin</oboInOwl:hasExactSynonym>
+        <rdfs:label>Trissin</rdfs:label>
     </owl:Class>
     
 
@@ -4263,14 +4293,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0038402">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">48 related 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">48-related 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">48-related-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5952</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bHLHa33</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fer2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ferritin 2</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fer2</rdfs:label>
+        <oboInOwl:hasExactSynonym>48 related 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>48-related 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>48-related-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG5952</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bHLHa33</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fer2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ferritin 2</oboInOwl:hasExactSynonym>
+        <rdfs:label>Fer2</rdfs:label>
     </owl:Class>
     
 
@@ -4279,13 +4309,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0038789">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">92a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15685</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR92a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR92a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 92a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 92a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir92a</rdfs:label>
+        <oboInOwl:hasExactSynonym>92a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG15685</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR92a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR92a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 92a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 92a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir92a</rdfs:label>
     </owl:Class>
     
 
@@ -4294,14 +4324,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0038798">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">92E.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">92a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17916</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR111</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR 92a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 92a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or92A</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or92a</rdfs:label>
+        <oboInOwl:hasExactSynonym>92E.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>92a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17916</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR111</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR 92a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 92a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or92A</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or92a</rdfs:label>
     </owl:Class>
     
 
@@ -4310,29 +4340,29 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0038901">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BURS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bur alpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Burs alpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Burs-alpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BursA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bursalpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bursicon</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bursicon alpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bursicon alpha subunit</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bursicon-alpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13419</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">burs</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">burs alpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">burs-alpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bursalpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bursicon</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bursicon alpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bursicon alpha subunit</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bursicon alpha-subunit</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">furled wing</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tBur</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Burs</rdfs:label>
+        <oboInOwl:hasExactSynonym>BURS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bur alpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Burs alpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Burs-alpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>BursA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bursalpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bursicon</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bursicon alpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bursicon alpha subunit</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bursicon-alpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13419</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>burs</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>burs alpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>burs-alpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bursalpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bursicon</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bursicon alpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bursicon alpha subunit</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bursicon alpha-subunit</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>frl</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>furled wing</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tBur</oboInOwl:hasExactSynonym>
+        <rdfs:label>Burs</rdfs:label>
     </owl:Class>
     
 
@@ -4341,16 +4371,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0039007">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCAP prepropeptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4910</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cardioacceleratory peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ccap</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crustacean Cardioactive Peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crustacean cardioactive peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmCCAP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ccap</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crustacean cardioactive peptide</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCAP</rdfs:label>
+        <oboInOwl:hasExactSynonym>CCAP prepropeptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG4910</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cardioacceleratory peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ccap</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Crustacean Cardioactive Peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Crustacean cardioactive peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmCCAP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ccap</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>crustacean cardioactive peptide</oboInOwl:hasExactSynonym>
+        <rdfs:label>CCAP</rdfs:label>
     </owl:Class>
     
 
@@ -4359,12 +4389,12 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0039033">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">94D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">94a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17241</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR108</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 94a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or94a</rdfs:label>
+        <oboInOwl:hasExactSynonym>94D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>94a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17241</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR108</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 94a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or94a</rdfs:label>
     </owl:Class>
     
 
@@ -4373,15 +4403,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0039034">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">94D.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">94b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6679</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR109</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR94b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 94b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-JP2002534971-A.31</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-JP2002534971-A.32</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or94b</rdfs:label>
+        <oboInOwl:hasExactSynonym>94D.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>94b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG6679</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR109</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR94b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 94b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-JP2002534971-A.31</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-JP2002534971-A.32</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or94b</rdfs:label>
     </owl:Class>
     
 
@@ -4390,13 +4420,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0039080">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">94h</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17382</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR94h</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR94h</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 94h</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 94h</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir94h</rdfs:label>
+        <oboInOwl:hasExactSynonym>94h</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17382</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR94h</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR94h</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 94h</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 94h</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir94h</rdfs:label>
     </owl:Class>
     
 
@@ -4405,16 +4435,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0039551">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">98B.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">98a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5540</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR110</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr98a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR98a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 98a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or-98a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or98A</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or98a</rdfs:label>
+        <oboInOwl:hasExactSynonym>98B.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>98a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG5540</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR110</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr98a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR98a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 98a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or-98a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or98A</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or98a</rdfs:label>
     </owl:Class>
     
 
@@ -4423,14 +4453,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0039582">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">98C.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">98b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1867</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR121</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 98b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or98bP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or98b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or98b</rdfs:label>
+        <oboInOwl:hasExactSynonym>98C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>98b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG1867</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR121</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 98b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or98bP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or98b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or98b</rdfs:label>
     </owl:Class>
     
 
@@ -4439,65 +4469,65 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0039722">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP-2b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP2B-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP2B-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP2B-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP2B-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP2B/pyrokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP2b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP2b-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP2b-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP2b-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAPA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAPA-PK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAPA-PVK-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAPA-PVK-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAPA-PVK/PK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP[[2b]]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15520</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CPPB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cap-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cap-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cap-2b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cap-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Capa-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Capa-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Capa-PK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Capability</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cardioacceleratory peptide-2b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-CAP-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-CAP-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-CAP2b/MT</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-MT</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-PK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-PK-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-PVK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-PVK-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-PVK-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-capa-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-myotropin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drome-capa-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PVK-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Periviscerokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pyrokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGPSASSGLWFGPRLamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cap2b-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">capa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">capa 2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">capa-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">capa-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">capa-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">capability</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cardio acceleratory peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myotropin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myotropin-CAP2b-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pyrokinin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pyrokinin-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pyrokinin-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pyrokinin/PBAN-like</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Capa</rdfs:label>
+        <oboInOwl:hasExactSynonym>CAP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP-2b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP2B-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP2B-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP2B-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP2B-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP2B/pyrokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP2b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP2b-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP2b-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP2b-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAPA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAPA-PK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAPA-PVK-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAPA-PVK-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAPA-PVK/PK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CAP[[2b]]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG15520</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CPPB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cap-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cap-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cap-2b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cap-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Capa-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Capa-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Capa-PK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Capability</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Cardioacceleratory peptide-2b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-CAP-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-CAP-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-CAP2b/MT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-MT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-PK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-PK-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-PVK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-PVK-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-PVK-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-capa-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-myotropin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drome-capa-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PVK-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Periviscerokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pyrokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TGPSASSGLWFGPRLamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cap2b-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>capa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>capa 2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>capa-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>capa-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>capa-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>capability</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cardio acceleratory peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myotropin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myotropin-CAP2b-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pyrokinin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pyrokinin-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pyrokinin-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pyrokinin/PBAN-like</oboInOwl:hasExactSynonym>
+        <rdfs:label>Capa</rdfs:label>
     </owl:Class>
     
 
@@ -4506,14 +4536,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0040849">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">41a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17587</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG33492</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR41a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR41a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 41a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 41a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir41a</rdfs:label>
+        <oboInOwl:hasExactSynonym>41a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17587</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG33492</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR41a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR41a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 41a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 41a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir41a</rdfs:label>
     </owl:Class>
     
 
@@ -4522,15 +4552,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041229">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">93F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13417</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR93</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR93F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR93a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr93F1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 93F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 93a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr93a</rdfs:label>
+        <oboInOwl:hasExactSynonym>93F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13417</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR93</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR93F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR93a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr93F1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 93F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 93a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr93a</rdfs:label>
     </owl:Class>
     
 
@@ -4539,14 +4569,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041231">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">68D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7303</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR68D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR68a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr68D1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 68D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 68a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr68a</rdfs:label>
+        <oboInOwl:hasExactSynonym>68D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG7303</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR68D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR68a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr68D1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 68D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 68a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr68a</rdfs:label>
     </owl:Class>
     
 
@@ -4555,17 +4585,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041243">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">43C.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">43C1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG1712</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGr43a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR43C.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR43a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr43C1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 43C.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 43a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gr43a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr43a</rdfs:label>
+        <oboInOwl:hasExactSynonym>43C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>43C1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG1712</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGr43a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR43C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR43a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr43C1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 43C.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 43a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gr43a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr43a</rdfs:label>
     </owl:Class>
     
 
@@ -4574,16 +4604,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041247">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">28A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13787</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR28A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR28a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28A2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 28A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 28A2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 28a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28a</rdfs:label>
+        <oboInOwl:hasExactSynonym>28A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13787</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR28A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR28a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28A2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 28A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 28A2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 28a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr28a</rdfs:label>
     </owl:Class>
     
 
@@ -4592,18 +4622,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041250">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(GR) 21a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">21D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13948</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGr21a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR21D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR21D1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR21a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr21D1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 21D.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 21a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gr21a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr21a</rdfs:label>
+        <oboInOwl:hasExactSynonym>(GR) 21a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>21D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13948</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGr21a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR21D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR21D1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR21a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr21D1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 21D.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 21a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gr21a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr21a</rdfs:label>
     </owl:Class>
     
 
@@ -4612,14 +4642,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041621">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">82a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG31519</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR61</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOR82A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr82a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR82a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 82a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or82a</rdfs:label>
+        <oboInOwl:hasExactSynonym>82a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG31519</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR61</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOR82A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr82a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR82a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 82a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or82a</rdfs:label>
     </owl:Class>
     
 
@@ -4628,24 +4658,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041622">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">69F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">69a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">69b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17902</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG32116</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG33264</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR82</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR83</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr69a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 69a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 69b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or69A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or69aA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or69aB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or69ab</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or69b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or69a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or69a</rdfs:label>
+        <oboInOwl:hasExactSynonym>69F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>69a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>69b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17902</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG32116</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG33264</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR82</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR83</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr69a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 69a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 69b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or69A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or69aA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or69aB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or69ab</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or69b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or69a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or69a</rdfs:label>
     </owl:Class>
     
 
@@ -4654,12 +4684,12 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041623">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">65c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG32403</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR65</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LU27.3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 65c</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or65c</rdfs:label>
+        <oboInOwl:hasExactSynonym>65c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG32403</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR65</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LU27.3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 65c</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or65c</rdfs:label>
     </owl:Class>
     
 
@@ -4668,12 +4698,12 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041624">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">65b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG32402</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR63</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LU27.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 65b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or65b</rdfs:label>
+        <oboInOwl:hasExactSynonym>65b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG32402</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR63</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LU27.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 65b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or65b</rdfs:label>
     </owl:Class>
     
 
@@ -4682,15 +4712,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041625">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">65a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG32401</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR66</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LU27.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR65a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 65a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">odorant receptor 65a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">or65a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or65a</rdfs:label>
+        <oboInOwl:hasExactSynonym>65a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG32401</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR66</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LU27.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR65a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 65a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>odorant receptor 65a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>or65a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or65a</rdfs:label>
     </owl:Class>
     
 
@@ -4699,15 +4729,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0041626">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">19A.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">19a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG18859</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOR37</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmOr19a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OR19a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 19a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or19a-1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or19a</rdfs:label>
+        <oboInOwl:hasExactSynonym>19A.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>19a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG18859</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DOR37</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmOr19a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OR19a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 19a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or19a-1</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or19a</rdfs:label>
     </owl:Class>
     
 
@@ -4716,10 +4746,10 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0043005">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG10251</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Portabella</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">portabella</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prt</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG10251</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Portabella</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>portabella</oboInOwl:hasExactSynonym>
+        <rdfs:label>prt</rdfs:label>
     </owl:Class>
     
 
@@ -4728,17 +4758,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0043576">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14746</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGRP SC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGRP-SC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGRP-SC1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGRP-SC1A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peptidoglycan recognition protein SC1a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peptidoglycan-recognition protein-SC1a precursor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pgrp-sc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pgrp-sc1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">picky</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGRP-SC1a</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14746</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PGRP SC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PGRP-SC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PGRP-SC1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PGRP-SC1A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Peptidoglycan recognition protein SC1a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Peptidoglycan-recognition protein-SC1a precursor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pgrp-sc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pgrp-sc1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>picky</oboInOwl:hasExactSynonym>
+        <rdfs:label>PGRP-SC1a</rdfs:label>
     </owl:Class>
     
 
@@ -4747,33 +4777,33 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0044046">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13317</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILP 7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILP-7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILP7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILPs</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dilp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dilp 7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dilp7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosophila insulin-like peptide 7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ILP7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ILPs</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ilp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ilp-7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin-like peptide 7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Relaxin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dILP-7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dILP7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dIlp7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dilp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dilp-7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dilp7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dlp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ilp7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin-like peptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin-like peptide 7</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ilp7</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG13317</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILP 7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILP-7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILP7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILPs</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dilp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dilp 7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dilp7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosophila insulin-like peptide 7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ILP7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ILPs</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ilp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ilp-7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin-like peptide 7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Relaxin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dILP-7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dILP7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dIlp7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dilp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dilp-7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dilp7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dlp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ilp7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin-like peptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin-like peptide 7</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ilp7</rdfs:label>
     </owl:Class>
     
 
@@ -4782,18 +4812,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0045476">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14988</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG32258</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG33157</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGr64e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmel64e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR64e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64A2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 64A2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 64e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gr64e</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64e</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14988</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG32258</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG33157</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGr64e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmel64e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR64e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr64A2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 64A2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 64e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gr64e</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr64e</rdfs:label>
     </owl:Class>
     
 
@@ -4802,14 +4832,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0045477">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14986</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG32256</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmel64c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR64c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 64c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gr64c</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64c</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14986</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG32256</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmel64c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR64c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 64c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gr64c</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr64c</rdfs:label>
     </owl:Class>
     
 
@@ -4818,18 +4848,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0045479">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14986</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG32261</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmel64a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR64a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRLU.3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GrLU3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 64a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor LU.3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LU.3</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64a</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14986</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG32261</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmel64a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR64a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GRLU.3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr64A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GrLU3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 64a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor LU.3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LU.3</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr64a</rdfs:label>
     </owl:Class>
     
 
@@ -4838,33 +4868,33 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0045495">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">28A3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13788</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR28B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR28B(D)</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR28b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRLU.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28A3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28A4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28b(D)</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28b.a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28b.b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28b.c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28b.d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28b.e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28bA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28bB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28bC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28bD</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28bE</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28be</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GrLU2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 28A4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 28b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor LU.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LU.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gr28b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr28b</rdfs:label>
+        <oboInOwl:hasExactSynonym>28A3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13788</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR28B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR28B(D)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR28b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GRLU.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28A3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28A4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28b(D)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28b.a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28b.b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28b.c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28b.d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28b.e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28bA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28bB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28bC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28bD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28bE</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr28be</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GrLU2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 28A4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 28b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor LU.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LU.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gr28b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr28b</rdfs:label>
     </owl:Class>
     
 
@@ -4873,14 +4903,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0045498">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG31930</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CR31930</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR22d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr22dP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr2940.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 22d</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 2940.2</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr22d</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG31930</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CR31930</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR22d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr22dP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr2940.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 22d</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 2940.2</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr22d</rdfs:label>
     </owl:Class>
     
 
@@ -4889,13 +4919,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0050263">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15677</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15679</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG30263</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT35864</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mdcds_15969</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stumble</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stum</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG15677</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG15679</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG30263</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT35864</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mdcds_15969</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>stumble</oboInOwl:hasExactSynonym>
+        <rdfs:label>stum</rdfs:label>
     </owl:Class>
     
 
@@ -4904,13 +4934,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0051718">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">31a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG31718</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR31a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR31a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 31a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 31a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir31a</rdfs:label>
+        <oboInOwl:hasExactSynonym>31a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG31718</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR31a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR31a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 31a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 31a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir31a</rdfs:label>
     </owl:Class>
     
 
@@ -4919,13 +4949,13 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0051956">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG31956</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8845</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8845b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Polypeptide N-Acetylgalactosaminyltransferase 4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pgant4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">polypeptide GalNAc transferase 4</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pgant4</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG31956</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG8845</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG8845b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Polypeptide N-Acetylgalactosaminyltransferase 4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pgant4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>polypeptide GalNAc transferase 4</oboInOwl:hasExactSynonym>
+        <rdfs:label>Pgant4</rdfs:label>
     </owl:Class>
     
 
@@ -4934,16 +4964,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0052255">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14988</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG32255</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmGr64f</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmel64f</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR64f</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64A3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 64A3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 64f</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr64f</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14988</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG32255</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmGr64f</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmel64f</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR64f</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr64</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr64A3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 64A3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 64f</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr64f</rdfs:label>
     </owl:Class>
     
 
@@ -4952,10 +4982,10 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0052693">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG32693</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR9a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 9a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr9a</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG32693</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR9a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 9a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr9a</rdfs:label>
     </owl:Class>
     
 
@@ -4964,15 +4994,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0053349">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15242</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG33349</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPK25</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ppk25</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">llz</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lounge lizard</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pickpocket 25</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ppk-25</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ppk25</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG15242</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG33349</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPK25</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ppk25</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>llz</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lounge lizard</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pickpocket 25</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ppk-25</oboInOwl:hasExactSynonym>
+        <rdfs:label>ppk25</rdfs:label>
     </owl:Class>
     
 
@@ -4981,21 +5011,38 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0053527">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AYRKPPFNGSLFamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG33527</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-IFa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-SIFa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IFAMIDE</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IFa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IFamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neb-LFamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIFR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIFamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIfamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">neuropeptide AYRKPPFNGSIFamide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">neuropeptide IFamide</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIFa</rdfs:label>
+        <oboInOwl:hasExactSynonym>AYRKPPFNGSLFamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG33527</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-IFa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-SIFa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IFAMIDE</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IFa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IFamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Neb-LFamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SIF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SIFR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SIFamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SIfamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>neuropeptide AYRKPPFNGSIFamide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>neuropeptide IFamide</oboInOwl:hasExactSynonym>
+        <rdfs:label>SIFa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://flybase.org/reports/FBgn0060296 -->
+
+    <owl:Class rdf:about="http://flybase.org/reports/FBgn0060296">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
+        <oboInOwl:hasExactSynonym>CG15860</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT31987</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EP2251</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PAINLESS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pain</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Painless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TRPA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>painless</oboInOwl:hasExactSynonym>
+        <rdfs:label>pain</rdfs:label>
     </owl:Class>
     
 
@@ -5004,11 +5051,11 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0062565">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG32825</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor 19b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Odorant receptor-19b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or-19b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Or19b</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG32825</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor 19b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Odorant receptor-19b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Or-19b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Or19b</rdfs:label>
     </owl:Class>
     
 
@@ -5017,15 +5064,15 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0085417">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14842</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14843</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG34388</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NTL</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natalisin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ntl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">natalisin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ntl</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">natalisin</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14842</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14843</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG34388</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NTL</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Natalisin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ntl</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>natalisin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ntl</oboInOwl:hasExactSynonym>
+        <rdfs:label>natalisin</rdfs:label>
     </owl:Class>
     
 
@@ -5034,38 +5081,38 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0085424">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15488</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG15489</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG34395</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6246</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NUB</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NUBBIN</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nub</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nubbin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oct-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oct1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDM-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDM1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">POU domain 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">POU domain protein 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">POU33F1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pdm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pdm-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pdm1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pdm1/nubbin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dOct1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dPOU-19</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dPOU-19/pdm-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dPOU19</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nb</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nubbin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pdm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pdm-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pdm1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">twain</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">twn</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nub</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG15488</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG15489</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG34395</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG6246</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NUB</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NUBBIN</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Nb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Nub</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Nubbin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Oct-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Oct1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDM-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PDM1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>POU domain 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>POU domain protein 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>POU33F1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pdm</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pdm-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pdm1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pdm1/nubbin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dOct1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dPOU-19</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dPOU-19/pdm-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dPOU19</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nb</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nubbin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pdm</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pdm-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pdm1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>twain</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>twn</oboInOwl:hasExactSynonym>
+        <rdfs:label>nub</rdfs:label>
     </owl:Class>
     
 
@@ -5074,39 +5121,39 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0086347">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG7438</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm IA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmIA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DroMIA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MYOIA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mhc1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myo-IA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myo1A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myo1D</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myo1a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MyoIA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MyoID</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myosin 1D</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myosin 31DF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myosin IA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myosin ID</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myosin-IA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myosin31DF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mhc1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myo1D</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myo31DF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myoID</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myosin 1a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myosin I</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myosin IA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myosin ID</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myosin-IA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myosin1A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">souther</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">type ID unconventional myosin 31DF</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unconventional myosin 31DF</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myo31DF</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG7438</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm IA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmIA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DroMIA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MYOIA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mhc1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myo-IA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myo1A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myo1D</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myo1a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MyoIA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>MyoID</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myosin 1D</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myosin 31DF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myosin IA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myosin ID</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myosin-IA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Myosin31DF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mhc1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myo1D</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myo31DF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myoID</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myosin 1a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myosin I</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myosin IA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myosin ID</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myosin-IA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>myosin1A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>souther</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>type ID unconventional myosin 31DF</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>unconventional myosin 31DF</oboInOwl:hasExactSynonym>
+        <rdfs:label>Myo31DF</rdfs:label>
     </owl:Class>
     
 
@@ -5115,26 +5162,26 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0086782">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amn</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amnesiac</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anm</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11937</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drm-amn</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EP(X)1442</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PACAP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PACAP-38</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PACAP-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PACAP38</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PACAP38-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pacap38</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pituitary adenylyl cyclase-activating polypeptide</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pituitary adenylyl cyclase-activating polypeptide-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amnesiac</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cheap date</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cheapdate</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chpd</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dAmn</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amn</rdfs:label>
+        <oboInOwl:hasExactSynonym>Amn</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Amnesiac</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Anm</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG11937</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drm-amn</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EP(X)1442</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PACAP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PACAP-38</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PACAP-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PACAP38</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PACAP38-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pacap38</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pituitary adenylyl cyclase-activating polypeptide</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pituitary adenylyl cyclase-activating polypeptide-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>amnesiac</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cheap date</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cheapdate</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>chpd</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dAmn</oboInOwl:hasExactSynonym>
+        <rdfs:label>amn</rdfs:label>
     </owl:Class>
     
 
@@ -5143,49 +5190,49 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0087002">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ApoL1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ApoL2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ApoLI</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ApoLII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ApoLpp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apolipophorin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apolpp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG11064</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DRBP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LPP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lipophorin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lpp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RFABG</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RFABP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RFBP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinoid and Fatty Acid Binding Glycoprotein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinoid and fatty-acid binding protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinoid- and Fatty Acid-binding Glycoprotein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinoid- and fatty acid-binding glycoprotein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinoid- and fatty acid-binding protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinoid- and fatty-acid binding protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinoid-fatty acid-binding glycoprotein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RfaBP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RfaBp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rfabg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rfabp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apoLI</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apoLII</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apoLPP</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apoLpp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apolipophorin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apolipophorin I</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apolipophorin II</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apolipophorin-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chr4:1088013..1088173</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lipophorin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">retinoid and fatty acid binding protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">retinoid- and fatty acid-binding gene</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">retinoid- and fatty acid-binding glycoprotein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">retinoid-fatty acid binding protein</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rfabg</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apolpp</rdfs:label>
+        <oboInOwl:hasExactSynonym>ApoL1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ApoL2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ApoLI</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ApoLII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ApoLpp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Apolipophorin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Apolpp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG11064</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DRBP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>LPP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lipophorin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Lpp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RFABG</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RFABP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RFBP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Retinoid and Fatty Acid Binding Glycoprotein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Retinoid and fatty-acid binding protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Retinoid- and Fatty Acid-binding Glycoprotein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Retinoid- and fatty acid-binding glycoprotein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Retinoid- and fatty acid-binding protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Retinoid- and fatty-acid binding protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Retinoid-fatty acid-binding glycoprotein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RfaBP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RfaBp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rfabg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Rfabp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>T3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>apoLI</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>apoLII</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>apoLPP</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>apoLpp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>apolipophorin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>apolipophorin I</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>apolipophorin II</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>apolipophorin-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>chr4:1088013..1088173</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lipophorin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>retinoid and fatty acid binding protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>retinoid- and fatty acid-binding gene</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>retinoid- and fatty acid-binding glycoprotein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>retinoid-fatty acid binding protein</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>rfabg</oboInOwl:hasExactSynonym>
+        <rdfs:label>apolpp</rdfs:label>
     </owl:Class>
     
 
@@ -5194,14 +5241,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0259185">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">60b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG13582</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG42289</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR60b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR60b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 60b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 60b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir60b</rdfs:label>
+        <oboInOwl:hasExactSynonym>60b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG13582</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG42289</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR60b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR60b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 60b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 60b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir60b</rdfs:label>
     </owl:Class>
     
 
@@ -5210,14 +5257,14 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0259194">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">94e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG17379</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG42298</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR94e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR94e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 94e</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 94e</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir94e</rdfs:label>
+        <oboInOwl:hasExactSynonym>94e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG17379</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG42298</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR94e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR94e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 94e</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 94e</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir94e</rdfs:label>
     </owl:Class>
     
 
@@ -5226,16 +5273,16 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0259683">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">40a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG42352</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5922</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5929</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR40a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR40a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 40a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir40A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 40a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir40a</rdfs:label>
+        <oboInOwl:hasExactSynonym>40a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG42352</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG5922</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG5929</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR40a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR40a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 40a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ir40A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 40a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir40a</rdfs:label>
     </owl:Class>
     
 
@@ -5244,19 +5291,19 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0259896">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BG:DS00180.10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8942</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT25688</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nim</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NimC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nimrod C1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NimrodC1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nimC1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nimrod</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nimrod C1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nimrodC1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NimC1</rdfs:label>
+        <oboInOwl:hasExactSynonym>BG:DS00180.10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG8942</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT25688</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Nim</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NimC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Nimrod C1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>NimrodC1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>P1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nimC1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nimrod</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nimrod C1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nimrodC1</oboInOwl:hasExactSynonym>
+        <rdfs:label>NimC1</rdfs:label>
     </owl:Class>
     
 
@@ -5265,36 +5312,36 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0260400">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">44C11</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9F8A9</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4262</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EC7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EG:65F1.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ELAV</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ELav</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">END1-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ElaV</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Elav</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Elav-9F8A9</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Embryonic Lethal Abnormal Vision</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Embryonic lethal abnormal vision</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Embryonic lethal abnormal visual system</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Embryonically lethal abnormal vision</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dHuR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">elav-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">elav-2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">elav-3</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">embryonic lethal abnormal vision</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">embryonic lethal abnormal visual system</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">embryonic lethal, abnormal vision</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fliJ</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)1Be</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)EC7</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)G0031</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(1)G0319</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">weg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">weniger</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">elav</rdfs:label>
+        <oboInOwl:hasExactSynonym>44C11</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>9F8A9</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG4262</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EC7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EG:65F1.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ELAV</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ELav</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>END1-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ElaV</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Elav</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Elav-9F8A9</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Embryonic Lethal Abnormal Vision</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Embryonic lethal abnormal vision</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Embryonic lethal abnormal visual system</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Embryonically lethal abnormal vision</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dHuR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>elav-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>elav-2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>elav-3</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>embryonic lethal abnormal vision</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>embryonic lethal abnormal visual system</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>embryonic lethal, abnormal vision</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fliJ</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)1Be</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)EC7</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)G0031</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(1)G0319</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>weg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>weniger</oboInOwl:hasExactSynonym>
+        <rdfs:label>elav</rdfs:label>
     </owl:Class>
     
 
@@ -5303,17 +5350,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0260874">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">76a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG34257</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG42584</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8533</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CT24909</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR76a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR76a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 76a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 76a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ir76a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir76a</rdfs:label>
+        <oboInOwl:hasExactSynonym>76a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG34257</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG42584</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG8533</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CT24909</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR76a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR76a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 76a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 76a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ir76a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir76a</rdfs:label>
     </owl:Class>
     
 
@@ -5322,11 +5369,11 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0260942">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bond</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6921</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">James bond</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">james bond</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bond</rdfs:label>
+        <oboInOwl:hasExactSynonym>Bond</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG6921</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>James bond</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>james bond</oboInOwl:hasExactSynonym>
+        <rdfs:label>bond</rdfs:label>
     </owl:Class>
     
 
@@ -5335,17 +5382,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0261401">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">75c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14586</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14586-A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG42642</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR75c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR75abc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR75c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 75c</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir75abc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 75c</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir75c</rdfs:label>
+        <oboInOwl:hasExactSynonym>75c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14586</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14586-A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG42642</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR75c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR75abc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR75c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 75c</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ir75abc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 75c</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir75c</rdfs:label>
     </owl:Class>
     
 
@@ -5354,17 +5401,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0261402">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">75b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14586</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14586-B</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG42643</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmelIR75b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR75abc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR75b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ionotropic receptor 75b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir75abc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ionotropic receptor 75b</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ir75b</rdfs:label>
+        <oboInOwl:hasExactSynonym>75b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14586</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG14586-B</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG42643</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmelIR75b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR75abc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR75b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ionotropic receptor 75b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Ir75abc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ionotropic receptor 75b</oboInOwl:hasExactSynonym>
+        <rdfs:label>Ir75b</rdfs:label>
     </owl:Class>
     
 
@@ -5373,9 +5420,9 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0263776">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG34239</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG6327</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG43693</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG34239</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG6327</oboInOwl:hasExactSynonym>
+        <rdfs:label>CG43693</rdfs:label>
     </owl:Class>
     
 
@@ -5384,22 +5431,22 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0264953">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG18103</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG31608</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG44122</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG8486</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmPIEZO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmPiezo</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmpiezo</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OrfKD</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Piezo</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anon-EST:Liang-1.32</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clone 1.32</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fos-related gene at 28F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fos28F</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fos500</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">piezo</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Piezo</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG18103</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG31608</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG44122</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG8486</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmPIEZO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmPiezo</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dmpiezo</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>OrfKD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Piezo</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anon-EST:Liang-1.32</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>clone 1.32</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fos-related gene at 28F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fos28F</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fos500</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>piezo</oboInOwl:hasExactSynonym>
+        <rdfs:label>Piezo</rdfs:label>
     </owl:Class>
     
 
@@ -5408,17 +5455,17 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0265139">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG18531</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EG:BACN32G11.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR1F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR2B1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR2a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr1F1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr2B1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 1F.1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 2B1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gustatory receptor 2a</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gr2a</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG18531</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EG:BACN32G11.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR1F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR2B1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR2a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr1F1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gr2B1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 1F.1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 2B1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gustatory receptor 2a</oboInOwl:hasExactSynonym>
+        <rdfs:label>Gr2a</rdfs:label>
     </owl:Class>
     
 
@@ -5427,24 +5474,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0266429">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASA-receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AST-R</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin A receptor 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allatostatin Receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AlstR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstA R1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstAR1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG2872</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D.AlstR1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAR-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAR1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DGR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dar-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EG:121E7.2</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Galanin Receptor</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AstA-R1</rdfs:label>
+        <oboInOwl:hasExactSynonym>ASA-receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ASR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AST-R</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin A receptor 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Allatostatin Receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AlstR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstA R1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>AstAR1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG2872</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D.AlstR1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DAR-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DAR1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DGR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dar-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EG:121E7.2</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>GR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Galanin Receptor</oboInOwl:hasExactSynonym>
+        <rdfs:label>AstA-R1</rdfs:label>
     </owl:Class>
     
 
@@ -5453,17 +5500,18 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0267796">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG14177</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3280</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG46121</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmTMC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TMC</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tic</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tmc-L</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transmembrane channel-like</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tmc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transmembrane channel-like</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tmc</rdfs:label>
+        <oboInOwl:hasExactSynonym>CG14177</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3280</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG46121</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmTMC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>TMC</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tic</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Tmc-L</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Transmembrane channel-like</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dTmc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tmc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>transmembrane channel-like</oboInOwl:hasExactSynonym>
+        <rdfs:label>Tmc</rdfs:label>
     </owl:Class>
     
 
@@ -5472,54 +5520,54 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0283437">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A[[1]]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Black Cell</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Black cell</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Black cells</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG42639</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5779</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diphenol oxidase A1 subunit</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmePPOA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dox-A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DoxA1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monophenol oxidase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monophenoloxidase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mox</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PO A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PO54</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPO-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPO-A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PROPO-A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phox</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pro-phenol oxidase A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ProPO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ProPO A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ProPO54</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ProPo</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prophenoloxidase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prophenoloxidase 1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prophenoloxidase A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Propo</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bc</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">black cells</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">i12</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phenoloxidase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pro-A</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pro-PO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pro-POA[[1]]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pro-phenol oxidase A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">proPO</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">proPO A[[1]]</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">proPO-A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">proPO54</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prophenol oxidase A1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prophenoloxidase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prophenoloxidase A[[1]]</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPO1</rdfs:label>
+        <oboInOwl:hasExactSynonym>A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>A[[1]]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Black Cell</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Black cell</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Black cells</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG42639</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG5779</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Diphenol oxidase A1 subunit</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmePPOA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dox-A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DoxA1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Monophenol oxidase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Monophenoloxidase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Mox</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PO A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PO54</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPO-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PPO-A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PROPO-A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Phox</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Pro-phenol oxidase A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ProPO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ProPO A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ProPO54</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ProPo</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Prophenoloxidase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Prophenoloxidase 1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Prophenoloxidase A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Propo</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bc</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>black cells</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>i12</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>phenoloxidase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pro-A</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pro-PO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pro-POA[[1]]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pro-phenol oxidase A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>proPO</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>proPO A[[1]]</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>proPO-A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>proPO54</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>prophenol oxidase A1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>prophenoloxidase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>prophenoloxidase A[[1]]</oboInOwl:hasExactSynonym>
+        <rdfs:label>PPO1</rdfs:label>
     </owl:Class>
     
 
@@ -5528,24 +5576,24 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0283442">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BG:DS00929.14</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG3506</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG43081</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG46283</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DDX4</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DmRH25</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EP(2)0812</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VAS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VASA</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vas</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vasa</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cgt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">courgette</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female sterile(2)ltoRJ36</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fs(2)ltoRJ36</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">no-relish</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vasa</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vas</rdfs:label>
+        <oboInOwl:hasExactSynonym>BG:DS00929.14</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG3506</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG43081</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG46283</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DDX4</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DmRH25</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>EP(2)0812</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>VAS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>VASA</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Vas</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Vasa</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cgt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>courgette</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>female sterile(2)ltoRJ36</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fs(2)ltoRJ36</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>no-relish</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>vasa</oboInOwl:hasExactSynonym>
+        <rdfs:label>vas</rdfs:label>
     </owl:Class>
     
 
@@ -5554,63 +5602,63 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0283499">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">18402</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG18402</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DIHR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DILR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DIR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DIRH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DIRbeta</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DInR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DInr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dir-a</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dir-b</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosophila Insulin Receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Drosophila insulin receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">INR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">INS</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Igf-1 receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Igfr1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inr-alpha</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inr-beta</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">InsR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin Receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin-like Receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin-like receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin-receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RTK</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dINR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dINSR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dIR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dIRH</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dInR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dInr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dInsR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dinR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dinr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dir</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">er10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inr</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin receptor homolog</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin receptor homologue</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin-like receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin-like receptor tyrosine kinase</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin-receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin/IGF receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insulin/insulin-like growth factor receptor</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)05545</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)93Dj</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(3)er10</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lethal(3)93Dj</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lnR</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sprout</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">InR</rdfs:label>
+        <oboInOwl:hasExactSynonym>18402</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG18402</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DIHR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DILR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DIR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DIRH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DIRbeta</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DInR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DInr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dir-a</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dir-b</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosophila Insulin Receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Drosophila insulin receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>INR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>INS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>IR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Igf-1 receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Igfr1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Inr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Inr-alpha</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Inr-beta</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>InsR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin Receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin-like Receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin-like receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Insulin-receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>RTK</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dINR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dINSR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dIR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dIRH</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dInR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dInr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dInsR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dinR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dinr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dir</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>er10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>inR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>inr</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin receptor homolog</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin receptor homologue</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin-like receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin-like receptor tyrosine kinase</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin-receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin/IGF receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>insulin/insulin-like growth factor receptor</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)05545</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)93Dj</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(3)er10</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lethal(3)93Dj</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lnR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sprout</oboInOwl:hasExactSynonym>
+        <rdfs:label>InR</rdfs:label>
     </owl:Class>
     
 
@@ -5619,47 +5667,47 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0284084">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Br</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bristled</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG4889</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Complementation group I</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D.int-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DWint-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DWnt-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dint-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm Wg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dm-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dwnt-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gla</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glazed</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">I</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sp</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sternopleural</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WG</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WNT</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wingless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wnt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wnt-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wnt1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dWnt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">flag</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glazed</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">int-1</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)02657</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)SH1281</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)SH2 1281</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)rO727</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">l(2)wg</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lethal (2) SH1281</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spade</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spd</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wgl</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wingless</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wnt</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wnt1</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wg</rdfs:label>
+        <oboInOwl:hasExactSynonym>Br</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Bristled</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG4889</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Complementation group I</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D.int-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DWint-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>DWnt-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dint-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm Wg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dm-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Dwnt-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Gla</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Glazed</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>I</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sp</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sternopleural</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>WG</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>WNT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Wg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Wingless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Wnt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Wnt-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Wnt1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dWnt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>flag</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>glazed</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>int-1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)02657</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)SH1281</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)SH2 1281</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)rO727</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>l(2)wg</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>lethal (2) SH1281</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spade</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>spd</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>wgl</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>wingless</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>wnt</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>wnt1</oboInOwl:hasExactSynonym>
+        <rdfs:label>wg</rdfs:label>
     </owl:Class>
     
 
@@ -5668,11 +5716,11 @@
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0285963">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BcDNA:GH07466</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG5518</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sda</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">slamdance</oboInOwl:hasExactSynonym>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CG46339</rdfs:label>
+        <oboInOwl:hasExactSynonym>BcDNA:GH07466</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>CG5518</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sda</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>slamdance</oboInOwl:hasExactSynonym>
+        <rdfs:label>CG46339</rdfs:label>
     </owl:Class>
     
 
@@ -5684,5 +5732,5 @@
 
 
 
-<!-- Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.26) https://github.com/owlcs/owlapi -->
 


### PR DESCRIPTION
This PR adds a couple of terms needed for annotation of midgut scRNAseq data in Petsakou et al. (2023):

* `enterocyte of adult middle midgut epithelium`, as a grouping term to encompass all enterocyte of the middle midgut regardless of their specialisations;
* `adult iron accumulating cell` as the adult equivalent of the existing `larval iron accumulating cell`, since such cells have also been reported in the adult midgut (a stage-neutral `iron accumulating cell` is also added).

The existing `adult midgut interstitial cell` gets two synonyms (`mEC` and `middle EC`) to reflect how cells of that type are referred to in this paper.

closes #1720