### PR TITLE
Unmap Uberon's 'insect dorsal ectoderm derivative'.

### DIFF
--- a/src/ontology/mappings.tsv
+++ b/src/ontology/mappings.tsv
@@ -401,7 +401,6 @@ FBbt:00006011	UBERON:6006011	exact	pharate adult
 FBbt:00006032	UBERON:6006032	exact	mesothoracic tergum primordium
 FBbt:00007020	UBERON:6007020	exact	metatarsus of male prothoracic leg
 FBbt:00007045	UBERON:6007045	exact	trunk ectoderm
-FBbt:00007046	UBERON:6007046	exact	dorsal ectoderm derivative
 FBbt:00007070	UBERON:6007070	exact	embryonic/larval posterior inferior protocerebrum
 FBbt:00007116	UBERON:6007116	exact	presumptive embryonic/larval system
 FBbt:00007145	UBERON:6007145	exact	adult protocerebrum


### PR DESCRIPTION
In Uberon, an ectoderm "derivative" is necessarily an anatomical structure, which is a _connected_ anatomical entity. In FBbt, a derivative can be any kind of anatomical entity, regardless of whether it is connected or disconnected.

Because of this difference, 'dorsal ectoderm derivative' in FBbt should not be mapped to 'insect dorsal ectoderm derivative' in Uberon.

None of the other 'derivative' terms in FBbt (e.g. mesodermal derivative, anterior endoderm derivative, etc.) are mapped to Uberon terms, and rightly so.

Related to https://github.com/obophenotype/uberon/issues/3190