### PR TITLE
Add a Uberon/CL integration test

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Run ontology QC checks
         env:
           DEFAULT_BRANCH: master
-        run: cd src/ontology && make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' IMP=false PAT=false pre_release && make SRC=fbbt-edit-release.owl ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' IMP=false PAT=false prepare_release
+        run: cd src/ontology && make IMP=false PAT=false prepare_release -B
 

--- a/.github/workflows/uberon-integration.yml
+++ b/.github/workflows/uberon-integration.yml
@@ -1,0 +1,81 @@
+name: Uberon integration
+
+on:
+  # Manual triggering only
+  workflow_dispatch:
+
+jobs:
+  uberon_integration:
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.4.3
+
+    steps:
+
+      - name: Checkout current FBbt
+        uses: actions/checkout@v4
+        with:
+          path: fbbt
+
+      - name: Checkout current Uberon
+        uses: actions/checkout@v4
+        with:
+          repository: obophenotype/uberon
+          path: uberon
+
+      - name: Checkout current CL
+        uses: actions/checkout@v4
+        with:
+          repository: obophenotype/cell-ontology
+          path: cl
+
+      - name: Build FBbt
+        run: |
+          cd fbbt/src/ontology
+          make fbbt.owl mappings.sssom.tsv MIR=false IMP=false PAT=false
+
+      - name: Build Uberon
+        run: |
+          cd uberon/src/ontology
+          make uberon.owl MIR=false IMP=false PAT=false BRI=false GH_ACTION=true
+
+      - name: Build CL
+        run: |
+          cd cl/src/ontology
+          make cl.owl MIR=false IMP=false PAT=false
+
+      - name: Merge all ontologies together
+        env:
+          ROBOT_PLUGINS_DIRECTORY: uberon/src/ontology/tmp/plugins
+        run: |
+          robot merge -i fbbt/src/ontology/fbbt.owl \
+                      -i uberon/src/ontology/uberon.owl \
+                      -i cl/src/ontology/cl.owl \
+                sssom:inject --sssom fbbt/src/ontology/mappings.sssom.tsv \
+                             --ruleset fbbt/src/scripts/bridging.rules \
+                annotate --ontology-iri http://purl.obolibrary.org/obo/fbbt/fbbt-uberon-cl-merge.owl \
+                         --output fbbt-uberon-cl-merge.owl \
+                reason --reasoner ELK | tee merge.log
+
+      - name: Upload merged ontology
+        uses: actions/upload-artifact@v4
+        with:
+          name: merged-ontology
+          path: fbbt-uberon-cl-merge.owl
+
+      - name: Check and explain unsats
+        run: |
+          if grep -q unsat merge.log ; then
+            robot explain -i fbbt-uberon-cl-merge.owl \
+                          --reasoner ELK \
+                          --mode unsatisfiability \
+                          --unsatisfiable all \
+                          --explanation unsats.md
+            exit 1
+          fi
+
+      - name: Upload explanations
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: explanations
+          path: unsats.md

--- a/src/scripts/bridging.rules
+++ b/src/scripts/bridging.rules
@@ -1,0 +1,22 @@
+prefix BFO:       <http://purl.obolibrary.org/obo/BFO_>
+prefix CL:        <http://purl.obolibrary.org/obo/CL_>
+prefix FBbt:      <http://purl.obolibrary.org/obo/FBbt_>
+prefix IAO:       <http://purl.obolibrary.org/obo/IAO_>
+prefix NCBITaxon: <http://purl.obolibrary.org/obo/NCBITaxon_>
+prefix UBERON:    <http://purl.obolibrary.org/obo/UBERON_>
+
+# Make sure FBbt classes are on the subject side
+object==FBbt:* -> invert();
+
+# Ignore any mapping that is not about FBbt
+# (there shouldn't be any but just in case)
+!subject==FBbt:* -> stop();
+
+# Ignore any mapping to an inexistent or obsolete foreign class.
+predicate==* -> check_object_existence();
+
+# Generate actual bridging axioms
+(object==UBERON:* || object==CL:*) && predicate==semapv:crossSpeciesExactMatch -> {
+    annotate_subject(IAO:0000589, "%object_label (Drosophila)");
+    create_axiom("%subject_id EquivalentTo: %object_id and (BFO:0000050 some NCBITaxon:7227)");
+}


### PR DESCRIPTION
This PR adds a new, manually triggered GitHub Action workflow that attempts to:

* build FBbt, Uberon, and CL from the tip of their main branches;
* merge the resulting ontologies together;
* check for unsatisfiable classes in the merged ontology.

The aim is to provide an easy way for any editor to quickly check that FBbt, Uberon, and CL are consistent with each other.

This is necessary because the standard test suite in each of those ontologies can only test whether each ontology is internally consistent after a change but cannot test whether that change creates inconsistencies when the ontology is merged with the other two. We could update the FBbt test suite to add a step in which we merge Uberon and CL, but that would create other problems: our test suite could fail at any time because of changes introduced in either Uberon or CL (unless Uberon and CL _also_ update their test suites to do the same, to avoid ever introducing any change that could break FBbt+Uberon+CL), so it would no longer fulfill its role of testing the changes we want to introduce in FBbt.

If the test finds unsatisfiable classes, a file containing explanations for them (obtained through `robot explain`) will be made available to editors.

Regardless of the presence of unsats, the file containing the merged ontology will also be made available to editors, should they wish to have a look at it.

(As an aside, this PR also updates the ODK-provided `qc.yml` file which contained out-of-date instructions to build the ontology. We do _not_ use that file currently – our CI is done on Travis – but updating it will allow us to switch our QC from Travis to GitHub Actions anytime, should we wish to do so.)