### PR TITLE
Prepare for ODK 1.5

### DIFF
--- a/src/ontology/fbbt-odk.yaml
+++ b/src/ontology/fbbt-odk.yaml
@@ -11,6 +11,10 @@ pattern_pipelines_group:
       dosdp_tools_options: "--obo-prefixes=true --restrict-axioms-to=logical"
     - id: all-axioms
       dosdp_tools_options: "--obo-prefixes=true"
+robot_plugins:
+  plugins:
+    - name: flybase
+      mirror_from: https://github.com/FlyBase/flybase-robot-plugin/releases/download/flybase-robot-plugin-0.1.1/flybase.jar
 namespaces: 
   - http://purl.obolibrary.org/obo/FBbt_
   - http://purl.obolibrary.org/obo/fbbt_

--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -69,7 +69,6 @@ $(REPORTDIR)/onto_metrics_calc.txt: $(ONT)-simple.obo install_flybase_scripts
 	$(SCRIPTSDIR)/onto_metrics_calc.pl 'fly_anatomy.ontology' $(ONT)-simple.obo > $@
 
 $(REPORTDIR)/chado_load_check_simple.txt: install_flybase_scripts fly_anatomy.obo
-	apt-get install -y --no-install-recommends libbusiness-isbn-perl
 	$(SCRIPTSDIR)/chado_load_checks.pl fly_anatomy.obo > $@
 
 $(REPORTDIR)/obo_qc_%.obo.txt:

--- a/src/ontology/fbbt.Makefile
+++ b/src/ontology/fbbt.Makefile
@@ -132,13 +132,7 @@ $(ONT)-full.obo: $(ONT)-full.owl
 # special placeholder string to substitute in definitions from external ontologies
 # FBbt only uses DOT definitions - to use SUB, copy code and sparql from FBcv.
 
-export ROBOT_PLUGINS_DIRECTORY = $(TMPDIR)/plugins
-
-$(ROBOT_PLUGINS_DIRECTORY)/flybase.jar:
-	mkdir -p $(ROBOT_PLUGINS_DIRECTORY)
-	curl -L -o $@ https://github.com/FlyBase/flybase-robot-plugin/releases/download/flybase-robot-plugin-0.1.0/flybase.jar
-
-$(EDIT_PREPROCESSED): $(SRC) $(ROBOT_PLUGINS_DIRECTORY)/flybase.jar
+$(EDIT_PREPROCESSED): $(SRC) all_robot_plugins
 	$(ROBOT) flybase:rewrite-def -i $< --dot-definitions --filter-prefix FBbt -o $@
 
 


### PR DESCRIPTION
Similar to https://github.com/FlyBase/drosophila-developmental-ontology/pull/92 for FBdv, this PR prepares the FBbt repository for the upcoming release of ODK 1.5.

In addition to removing the step that installs `libbusiness-isbn-perl` (not needed anymore as the package is already included in the new ODK), this removes the custom step that installs the FlyBase ROBOT plugin, to let the ODK take care of the installation instead.