### PR TITLE
Add type II and type II GMCs

### DIFF
--- a/src/ontology/components/flybase_import.owl
+++ b/src/ontology/components/flybase_import.owl
@@ -2072,6 +2072,23 @@
     
 
 
+    <!-- http://flybase.org/reports/FBgn0020378 -->
+
+    <owl:Class rdf:about="http://flybase.org/reports/FBgn0020378">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0000704"/>
+        <oboInOwl:hasExactSynonym>CG1343</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D-Sp1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D-Sp8</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>D.Sp1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>SP1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Sp1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>dSp1</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sp1</oboInOwl:hasExactSynonym>
+        <rdfs:label>Sp1</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://flybase.org/reports/FBgn0020386 -->
 
     <owl:Class rdf:about="http://flybase.org/reports/FBgn0020386">


### PR DESCRIPTION
This PR adds `type I ganglion mother cell` and `type II ganglion mother cell` as subtypes of `ganglion mother cell`.

closes #1812 