### PR TITLE
Complete mappings to CL’s photoreceptor cells.

### DIFF
--- a/src/mappings/mappings.tsv
+++ b/src/mappings/mappings.tsv
@@ -40,7 +40,16 @@ FBbt:00005147	CL:0000468	exact	neuroglioblast
 FBbt:00005149	CL:0000469	exact	ganglion mother cell
 FBbt:00001687	CL:0000396	exact	lamellocyte
 FBbt:00000124	CL:0000066	exact	epithelial cell
-FBbt:00004211	CL:2000019	exact	photoreceptor cell
+FBbt:00004211	CL:0000210	exact	photoreceptor cell
+FBbt:00006009	CL:2000019	exact	eye photoreceptor cell
+FBbt:00004213	CL:0000687	exact	photoreceptor cell R1
+FBbt:00004215	CL:0000690	exact	photoreceptor cell R2
+FBbt:00004217	CL:0000694	exact	photoreceptor cell R3
+FBbt:00004219	CL:0000697	exact	photoreceptor cell R4
+FBbt:00004221	CL:0000702	exact	photoreceptor cell R5
+FBbt:00004223	CL:0000705	exact	photoreceptor cell R6
+FBbt:00004225	CL:0000707	exact	photoreceptor cell R7
+FBbt:00004227	CL:0000709	exact	photoreceptor cell R8
 FBbt:00001689	CL:0000395	exact	procrystal cell
 FBbt:00004994	CL:0000464	exact	epidermoblast
 FBbt:00001789	CL:0000373	exact	histoblast


### PR DESCRIPTION
Re-map `photoreceptor neuron` to CL’s `photoreceptor cell`. Map all R1, R2, ... R8 photoreceptor cells to the corresponding terms in CL.

See https://github.com/obophenotype/cell-ontology/issues/2342