### PR TITLE
Use latest ODK image in uberon-integration

### DIFF
--- a/.github/workflows/uberon-integration.yml
+++ b/.github/workflows/uberon-integration.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   uberon_integration:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.2
 
     steps:
 


### PR DESCRIPTION
Update the Uberon integration workflow to make sure we are using the latest ODK image (1.5.2).

Version 1.5 of the ODK is no longer suitable, as compiling the mappings now requires SSSOM-CLI's `-p` option (which is not available in the version of SSSOM-CLI provided with ODK 1.5).