### PR TITLE
Remap 'multi-cell-component structure' to the equivalent Uberon term.

### DIFF
--- a/src/mappings/common.sssom.tsv
+++ b/src/mappings/common.sssom.tsv
@@ -420,7 +420,7 @@ FBbt:00007020	metatarsus of male prothoracic leg	semapv:crossSpeciesExactMatch	U
 FBbt:00007027	cuboidal/columnar epithelium	semapv:crossSpeciesExactMatch	UBERON:0000485	semapv:ManualMappingCuration	
 FBbt:00007045	trunk ectoderm	semapv:crossSpeciesExactMatch	UBERON:6007045	semapv:ManualMappingCuration	
 FBbt:00007060	multi-cell-component structure	semapv:crossSpeciesNarrowMatch	CARO:0001000	semapv:ManualMappingCuration	
-FBbt:00007060	multi-cell-component structure	semapv:crossSpeciesNarrowMatch	UBERON:0005162	semapv:ManualMappingCuration	
+FBbt:00007060	multi-cell-component structure	semapv:crossSpeciesExactMatch	UBERON:0005162	semapv:ManualMappingCuration	
 FBbt:00007070	embryonic/larval posterior inferior protocerebrum	semapv:crossSpeciesExactMatch	UBERON:6007070	semapv:ManualMappingCuration	
 FBbt:00007091	subperineurial glial sheath	semapv:crossSpeciesCloseMatch	UBERON:0000202	semapv:ManualMappingCuration	Debatable: the subperineurial glia does act “like” a BBB but is it enough to make the two terms equivalent?
 FBbt:00007108	imaginal disc epithelial cell	semapv:crossSpeciesExactMatch	CL:0000429	semapv:ManualMappingCuration	


### PR DESCRIPTION
Uberon has followed FBbt in broadening the definition of 'multi cell part structure' to avoid excluding the presence of complete cells, so we can remap our 'multi-cell-component structure' as an exact match to the Uberon term.

We leave the mapping to CARO:0001000 as a narrow match, as the CARO term is unlikely to ever be modified in the same way since CARO is, in effect, no longer maintained.

closes #2102