### PR TITLE
Update SSSOM/T-OWL rules.

### DIFF
--- a/src/scripts/sssom2xrefs.rules
+++ b/src/scripts/sssom2xrefs.rules
@@ -10,4 +10,4 @@ subject==FBbt:*
     || predicate==skos:exactMatch
     || predicate==skos:narrowMatch
     || predicate==skos:relatedMatch)
-  -> annotate_subject(oio:hasDbXref, "%object_curie");
+  -> annotate(%{subject_id}, oio:hasDbXref, %{object_id|short});


### PR DESCRIPTION
The `sssom2xrefs.rules` SSSOM/T-OWL ruleset, used to generate the `mappings_xrefs.owl` component, is using some deprecated, pre-1.0 SSSOM/T-OWL features that will no longer be supported in a future version of SSSOM-Java:

* the `annotate_subject` generator function;
* the `%object_curie` placeholder.

We update the ruleset to use the modern equivalents of those features.