### PR TITLE
Use ODK 1.6 in the Uberon integration test.

### DIFF
--- a/.github/workflows/uberon-integration.yml
+++ b/.github/workflows/uberon-integration.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   uberon_integration:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.2
+    container: obolibrary/odkfull:v1.6
 
     steps:
 


### PR DESCRIPTION
Building FBbt now requires the ODK 1.6, so the Uberon integration test needs to be updated to use that version.